### PR TITLE
Fix default build targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,10 +13,6 @@ IF(CMAKE_BUILD_TYPE STREQUAL "" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebug")
   SET(CMAKE_BUILD_TYPE "RelWithDebInfo")
 ENDIF()
 
-# Change `RelWithDebInfo` g2 -O2 -DDEBUG`
-string(REGEX REPLACE "-DNDEBUG " "" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -DDEBUG" )
-string(REGEX REPLACE "-DNDEBUG " "" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -DDEBUG" )
-
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules/")
 SET(CMAKE_INSTALL_LIBDIR ${CMAKE_BINARY_DIR}/lib)
 SET(CMAKE_INSTALL_BINDIR ${CMAKE_BINARY_DIR}/bin)
@@ -31,9 +27,11 @@ option(WITH_ZSTD "build with zstd" ON)
 option(WITH_BZ2 "build with bzip2" ON)
 option(WITH_WINDOWS_UTF8_FILENAMES "use UTF8 as characterset for opening files, regardles of the system code page" OFF)
 option(WITH_BYTEDANCE_METRICS "build with bytedance internal metrics" OFF)
-option(WITH_ASAN "build with ASAN" ON)
+option(WITH_ASAN "build with ASAN" OFF)
 option(WITH_GFLAGS "build with GFlags" ON)
-option(WITH_TESTS "build with tests" OFF)
+include(CMakeDependentOption)
+# Tests are excluded from Release builds
+CMAKE_DEPENDENT_OPTION(WITH_TESTS "build with tests" ON "CMAKE_BUILD_TYPE STREQUAL Debug" OFF)
 option(WITH_TOOLS "build with tools" OFF)
 option(WITH_TERARK_ZIP "build with TerarkZipTable support" ON)
 option(WITH_BOOSTLIB "build with boost, if WITH_TERARK_ZIP is ON, this will also set to ON" OFF)
@@ -45,16 +43,6 @@ SET(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 Find_Package(Threads REQUIRED)
 
 #----------------------- Global Options
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin" OR CMAKE_BUILD_TYPE STREQUAL "Release" OR WITH_JEMALLOC)
-  set(WITH_ASAN OFF)
-endif()
-
-
-# RocksDB's UT has to be run under Debug or RelWithDebInfo mode
-if(CMAKE_BUILD_TYPE STREQUAL "Release")
-  SET(WITH_TESTS OFF CACHE BOOL OFF)
-endif()
-
 if (WITH_WINDOWS_UTF8_FILENAMES)
   add_definitions(-DROCKSDB_WINDOWS_UTF8_FILENAMES)
 endif()
@@ -254,6 +242,7 @@ endif(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64le")
 option(PORTABLE "build a portable binary" OFF)
 option(FORCE_SSE42 "force building with SSE4.2, even when PORTABLE=ON" OFF)
 if(PORTABLE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=haswell")
   # MSVC does not need a separate compiler flag to enable SSE4.2; if nmmintrin.h
   # is available, it is available by default.
   if(FORCE_SSE42 AND NOT MSVC)
@@ -264,7 +253,7 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX2")
   else()
     if(NOT HAVE_POWER8)
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=haswell")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
     endif()
   endif()
 endif()
@@ -371,7 +360,7 @@ if(DISABLE_STALL_NOTIF)
   add_definitions(-DROCKSDB_DISABLE_STALL_NOTIFICATION)
 endif()
 
-SET(USE RTTI ON)
+SET(USE_RTTI ON)
 if(DEFINED USE_RTTI)
   if(USE_RTTI)
     message(STATUS "Enabling RTTI")

--- a/build.sh
+++ b/build.sh
@@ -6,5 +6,5 @@ mkdir -p $OUTPUT
 
 git submodule update --init --recursive
 
-cd $BASE/$OUTPUT && cmake ../ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_TESTS=OFF -DWITH_TOOLS=ON -DWITH_TERARK_ZIP=ON
+cd $BASE/$OUTPUT && cmake ../ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_TOOLS=ON -DWITH_TERARK_ZIP=ON
 cd $BASE/$OUTPUT && make -j $(nproc) && make install

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -29,7 +29,7 @@ IF(WITH_SNAPPY)
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/snappy
         CONFIGURE_COMMAND rm -rf build && mkdir -p build
         BUILD_IN_SOURCE 1
-        BUILD_COMMAND cd build && cmake ../ -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR} -DCMAKE_BUILD_TYPE=Release -DSNAPPY_BUILD_TESTS=OFF -DHAVE_LIBLZO2=OFF && make -j 10
+        BUILD_COMMAND cd build && cmake ../ -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR} -DCMAKE_INSTALL_LIBDIR=${CMAKE_BINARY_DIR}/lib -DCMAKE_BUILD_TYPE=Release -DSNAPPY_BUILD_TESTS=OFF -DHAVE_LIBLZO2=OFF && make -j $(nproc)
         INSTALL_COMMAND cd build && ls -l && make install && cd ../ && rm -rf build)
     ADD_LIBRARY(snappy STATIC IMPORTED GLOBAL)
     ADD_DEPENDENCIES(snappy snappy-project)
@@ -49,7 +49,7 @@ IF(WITH_BYTEDANCE_METRICS)
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/metrics2-cmake	
         CONFIGURE_COMMAND rm -rf cmake-build && mkdir -p cmake-build && mkdir -p ${CMAKE_BINARY_DIR}/lib	
         BUILD_IN_SOURCE 1	
-        BUILD_COMMAND cd cmake-build && cmake ../ -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} && make -j $(nproc)	
+        BUILD_COMMAND cd cmake-build && cmake ../ -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} && make -j $(nproc)
         # metrics2 doesn't have a install instruction, so we have to manully install it	
         INSTALL_COMMAND cp cmake-build/libmetrics2.a ${CMAKE_BINARY_DIR}/lib/)	
     ADD_LIBRARY(metrics2 STATIC IMPORTED GLOBAL)	
@@ -91,7 +91,7 @@ IF(WITH_GFLAGS)
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/gflags
         CONFIGURE_COMMAND rm -rf build-cmake && mkdir -p build-cmake
         BUILD_IN_SOURCE 1
-        BUILD_COMMAND cd build-cmake && cmake ../ -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR} -DCMAKE_BUILD_TYPE=Release && make -j 10
+        BUILD_COMMAND cd build-cmake && cmake ../ -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR} -DCMAKE_BUILD_TYPE=Release && make -j $(nproc)
         INSTALL_COMMAND cd build-cmake && make install)
     ADD_LIBRARY(gflags STATIC IMPORTED GLOBAL)
     ADD_DEPENDENCIES(gflags gflags-project)
@@ -111,7 +111,7 @@ IF(WITH_ZSTD)
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/zstd
         CONFIGURE_COMMAND ""
         BUILD_IN_SOURCE 1
-        BUILD_COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR}/zstd && make "CXXFLAGS=-fPIC -O2" "CFLAGS=-fPIC -O2" -j 10
+        BUILD_COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR}/zstd && make "CXXFLAGS=-fPIC -O2" "CFLAGS=-fPIC -O2" -j $(nproc)
         INSTALL_COMMAND PREFIX=${CMAKE_BINARY_DIR} make install)
     ADD_LIBRARY(zstd STATIC IMPORTED GLOBAL)
     ADD_DEPENDENCIES(zstd zstd-project)
@@ -132,7 +132,7 @@ IF(WITH_LZ4)
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lz4
         CONFIGURE_COMMAND ""
         BUILD_IN_SOURCE 1
-        BUILD_COMMAND make "CXXFLAGS=-fPIC -O2" "CFLAGS=-fPIC -O2" -j 10
+        BUILD_COMMAND make "CXXFLAGS=-fPIC -O2" "CFLAGS=-fPIC -O2" -j $(nproc)
         INSTALL_COMMAND prefix=${CMAKE_BINARY_DIR} make install)
     ADD_LIBRARY(lz4 STATIC IMPORTED GLOBAL)
     ADD_DEPENDENCIES(lz4 lz4-project)
@@ -152,7 +152,7 @@ IF(WITH_BZ2)
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/bzip2
         CONFIGURE_COMMAND ""
         BUILD_IN_SOURCE 1
-        BUILD_COMMAND make "CXXFLAGS=-fPIC -O2" "CFLAGS=-fPIC -O2" -j 4
+        BUILD_COMMAND make "CXXFLAGS=-fPIC -O2" "CFLAGS=-fPIC -O2" -j $(nproc)
         INSTALL_COMMAND make install PREFIX=${CMAKE_BINARY_DIR} && make clean)
     ADD_LIBRARY(bzip2 STATIC IMPORTED GLOBAL)
     ADD_DEPENDENCIES(bzip2 bzip2-project)
@@ -172,7 +172,7 @@ IF(WITH_JEMALLOC)
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/jemalloc
         CONFIGURE_COMMAND ""
         BUILD_IN_SOURCE 1
-        BUILD_COMMAND bash autogen.sh && "CFLAGS=-fPIC" "CXXFLAGS=-fPIC" "LDFLAGS=-fPIC" ./configure --prefix=${CMAKE_BINARY_DIR} --enable-prof && make -j 20
+        BUILD_COMMAND bash autogen.sh && "CFLAGS=-fPIC" "CXXFLAGS=-fPIC" "LDFLAGS=-fPIC" ./configure --prefix=${CMAKE_BINARY_DIR} --enable-prof && make -j $(nproc)
         INSTALL_COMMAND make install PREFIX=${CMAKE_BINARY_DIR} && make clean)
     ADD_LIBRARY(jemalloc STATIC IMPORTED GLOBAL)
     ADD_DEPENDENCIES(jemalloc jemalloc-project)


### PR DESCRIPTION
1. Fix a typo with regard to RTTI
2. Compiles non-portable versions correctly
3. Parallel build dependencies when possible
4. Default (in `build.sh`) builds a RelWithDebInfo target(Release without strip)
5. Only debug target builds unit-tests by default
6. All output libraries are in the same folder