### PR TITLE
workaround race conditions during `PeriodicWorkScheduler` registratio…

### DIFF
--- a/db/periodic_work_scheduler.h
+++ b/db/periodic_work_scheduler.h
@@ -44,6 +44,12 @@ class PeriodicWorkScheduler {
 
  protected:
   std::unique_ptr<Timer> timer;
+  // `timer_mu_` serves two purposes currently:
+  // (1) to ensure calls to `Start()` and `Shutdown()` are serialized, as
+  //     they are currently not implemented in a thread-safe way; and
+  // (2) to ensure the `Timer::Add()`s and `Timer::Start()` run atomically, and
+  //     the `Timer::Cancel()`s and `Timer::Shutdown()` run atomically.
+  port::Mutex timer_mu_;
 
   explicit PeriodicWorkScheduler(Env* env);
 

--- a/util/timer.h
+++ b/util/timer.h
@@ -46,6 +46,7 @@ class Timer {
         cond_var_(&mutex_),
         running_(false),
         executing_task_(false) {}
+  ~Timer() { Shutdown(); }
   // Add a new function to run.
   // fn_name has to be identical, otherwise, the new one overrides the existing
   // one, regardless if the function is pending removed (invalid) or not.

--- a/util/timer.h
+++ b/util/timer.h
@@ -24,6 +24,9 @@ namespace TERARKDB_NAMESPACE {
 
 // A Timer class to handle repeated work.
 //
+// `Start()` and `Shutdown()` are currently not thread-safe. The client must
+// serialize calls to these two member functions.
+//
 // A single timer instance can handle multiple functions via a single thread.
 // It is better to leave long running work to a dedicated thread pool.
 //


### PR DESCRIPTION
…n (#7888)

Summary:
This provides a workaround for two race conditions that will be fixed in
a more sophisticated way later. This PR:

(1) Makes the client serialize calls to `Timer::Start()` and `Timer::Shutdown()` (see https://github.com/facebook/rocksdb/issues/7711). The long-term fix will be to make those functions thread-safe.
(2) Makes `PeriodicWorkScheduler` atomically add/cancel work together with starting/shutting down its `Timer`. The long-term fix will be for `Timer` API to offer more specialized APIs so the client will not need to synchronize.

Pull Request resolved: https://github.com/facebook/rocksdb/pull/7888

Test Plan: ran the repro provided in https://github.com/facebook/rocksdb/issues/7881

Reviewed By: jay-zhuang

Differential Revision: D25990891

Pulled By: ajkr

fbshipit-source-id: a97fdaebbda6d7db7ddb1b146738b68c16c5be38