### PR TITLE
ci: fix GitHub Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,11 @@ name: Build
 
 on:
   pull_request:
-    branches: 
+    branches:
+      - master
+      - dev.*
+  push:
+    branches:
       - master
       - dev.*
 
@@ -20,8 +24,17 @@ jobs:
       run: |
         sudo apt-get install -y libaio-dev
         git submodule update --init --recursive
-        cmake -E make_directory build
 
+    - uses: actions/cache@v2
+      name: Recover from cache
+      with:
+        path: |
+          build/
+        key: ${{ runner.os }}-cmake-${{ hashFiles('CMakeLists.txt') }}
+    
+    - name: Create Build Directory
+      run: cmake -E make_directory build || true
+        
     - name: CMake
       working-directory: build
       run: cmake .. -DCMAKE_BUILD_TYPE=Debug -DWITH_TESTS=ON -DWITH_TOOLS=ON
@@ -29,7 +42,3 @@ jobs:
     - name: Build
       working-directory: build
       run: make
-
-    - name: Test
-      working-directory: build
-      run: make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,4 +41,4 @@ jobs:
 
     - name: Build
       working-directory: build
-      run: make
+      run: make -j2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,10 @@
-name: CMake
+name: Build
 
 on:
   pull_request:
     branches: 
       - master
       - dev.*
-
-env:
-  BUILD_TYPE: RelWithDebInfo
 
 jobs:
   build:
@@ -23,19 +20,16 @@ jobs:
       run: |
         sudo apt-get install -y libaio-dev
         git submodule update --init --recursive
-        cmake -E make_directory ${{runner.workspace}}/build
+        cmake -E make_directory build
 
-    - name: Configure CMake
-      shell: bash
-      working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_TESTS=ON -DWITH_TOOLS=ON
+    - name: CMake
+      working-directory: build
+      run: cmake .. -DCMAKE_BUILD_TYPE=Debug -DWITH_TESTS=ON -DWITH_TOOLS=ON
 
     - name: Build
-      working-directory: ${{runner.workspace}}/build
-      shell: bash
-      run: make -j $(nproc)
+      working-directory: build
+      run: make
 
     - name: Test
-      working-directory: ${{runner.workspace}}/build
-      shell: bash
+      working-directory: build
       run: make test


### PR DESCRIPTION
In this PR, we have fixed several problems in current GitHub Action CI workflow.

* We use `DEBUG` as CMake configuration, so as to successfully generate the test targets
* And we also simplified the CI configurations.
* Also, @mm304321141 enabled GitHub Action for this repo, for all GitHub users.

Note that we have not enabled clang-format check. After some internal discussions, TerarkDB is still in rapid development, and has not yet been ready for such enforcements.

Unit tests might fail or take a very long time to execute. We could later see what test to enable or disable.