### PR TITLE
add garbage collection for ZenFS

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -68,6 +68,7 @@
 #include "table/block_based_table_factory.h"
 #include "table/merging_iterator.h"
 #include "table/two_level_iterator.h"
+#include "third-party/zenfs/fs/zbd_stat.h"
 #include "util/autovector.h"
 #include "util/build_version.h"
 #include "util/c_style_callback.h"
@@ -112,6 +113,8 @@
 #endif
 
 namespace TERARKDB_NAMESPACE {
+
+std::vector<ZoneStat> GetStat(Env* env);
 
 const std::string kDefaultColumnFamilyName("default");
 const uint64_t kDumpStatsWaitMicroseconds = 10000;

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1036,8 +1036,9 @@ void DBImpl::ScheduleZNSGC() {
         std::string strip_filename;
 
         for (const auto& path : db_paths) {
-          if (Slice(file.filename).starts_with(path.path)) {
-            strip_filename = file.filename.substr(path.path.length());
+          if (Slice(file.filename).starts_with(path)) {
+            strip_filename.assign(file.filename, path.length(),
+                                  file.filename.length() - path.length());
             break;
           }
         }

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1028,8 +1028,6 @@ void DBImpl::ScheduleZNSGC() {
     db_paths.emplace(path.path);
   }
 
-  for(const auto& path : db_paths) { std::cerr << path << std::endl; }
-
   std::string strip_filename;
 
   for (const auto& zone : stat) {

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1050,8 +1050,8 @@ void DBImpl::ScheduleZNSGC() {
         continue;
       }
 
-      // > 50% space could be recycled
-      if (total_size <= initial_db_options_.zenfs_gc_ratio * written_data) {
+      // if data in zone <= (1 - ratio) * total_capacity, recycle the zone
+      if (total_size <= (1.0 - initial_db_options_.zenfs_gc_ratio) * written_data) {
         for (auto&& file_id : sst_in_zone) {
           mark_for_gc.insert(file_id);
         }

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -985,6 +985,134 @@ void DBImpl::ScheduleTtlGC() {
   log_buffer_debug.FlushBufferToLog();
 }
 
+#ifdef LIBZBD
+void DBImpl::ScheduleZNSGC() {
+  TEST_SYNC_POINT("DBImpl:ScheduleZNSGC");
+  uint64_t nowSeconds = env_->NowMicros() / 1000U / 1000U;
+  LogBuffer log_buffer_info(InfoLogLevel::INFO_LEVEL,
+                            immutable_db_options_.info_log.get());
+  LogBuffer log_buffer_debug(InfoLogLevel::DEBUG_LEVEL,
+                             immutable_db_options_.info_log.get());
+
+  chash_set<uint64_t> mark_for_gc;
+
+  // pick files for GC
+  auto stat = GetStat(env_);
+
+  uint64_t number;
+  FileType type;
+
+  for (auto&& zone : stat) {
+    std::vector<uint64_t> sst_in_zone;
+    uint64_t written_data = zone.write_position - zone.start_position;
+    // zone is full
+    if (written_data == zone.total_capacity) {
+      uint64_t total_size = 0;
+      bool ignore_zone = false;
+      for (auto&& file : zone.files) {
+        std::string strip_filename;
+
+        for (auto&& path : immutable_db_options_.db_paths) {
+          if (Slice(file.filename).starts_with(path.path)) {
+            strip_filename = file.filename.substr(path.path.length());
+            break;
+          }
+        }
+
+        if (strip_filename.empty()) {
+          // This file is not in DB folder.
+          ignore_zone = true;
+          break;
+        }
+
+        if (ParseFileName(strip_filename, &number, Slice(), &type)) {
+          // Is SST file, and is of current TerarkDB instance.
+          if (type == kTableFile) {
+            total_size += file.size_in_zone;
+            sst_in_zone.push_back(number);
+          } else {
+            // This zone contains file other than SSTs or files from other
+            // databases. We ignore the zone for now. When other files (like
+            // logs) have been deleted, we will come back and recycle this zone.
+            ignore_zone = true;
+            break;
+          }
+        } else {
+          // This file is not recognized by TerarkDB (or RocksDB). Even if we
+          // move the file, the zone may not be reset. Therefore, we simply
+          // ignore this zone.
+          ignore_zone = true;
+          break;
+        }
+      }
+
+      if (ignore_zone) {
+        continue;
+      }
+
+      // > 50% space could be recycled
+      if (total_size <= initial_db_options_.zenfs_gc_ratio * written_data) {
+        for (auto&& file_id : sst_in_zone) {
+          mark_for_gc.insert(file_id);
+        }
+      }
+    }
+  }
+
+  mutex_.Lock();
+  for (auto cfd : *versions_->GetColumnFamilySet()) {
+    uint64_t new_mark_count = 0;
+    uint64_t old_mark_count = 0;
+    uint64_t total_count = 0;
+    if (!cfd->initialized() || cfd->IsDropped()) {
+      continue;
+    }
+    VersionStorageInfo* vstorage = cfd->current()->storage_info();
+    // Level -1 contains SSTs inside lazy compaction SST index.
+    // By iterating level -1, we could collect that kind of garbage.
+    // But we still recommend using ZNS GC without lazy compaction
+    // enabled.
+    for (int l = -1; l < vstorage->num_non_empty_levels(); l++) {
+      for (auto meta : vstorage->LevelFiles(l)) {
+        if (meta->being_compacted) {
+          continue;
+        }
+        ++total_count;
+        old_mark_count += meta->marked_for_compaction;
+        TEST_SYNC_POINT("DBImpl:Exist-SST");
+        if (!meta->marked_for_compaction &&
+            mark_for_gc.count(meta->fd.GetNumber()) > 0) {
+          meta->marked_for_compaction = true;
+        }
+        if (meta->marked_for_compaction) {
+          new_mark_count++;
+          TEST_SYNC_POINT("DBImpl:ScheduleZNSGC-mark");
+        }
+      }
+    }
+    if (new_mark_count > old_mark_count) {
+      vstorage->ComputeCompactionScore(*cfd->ioptions(),
+                                       *cfd->GetLatestMutableCFOptions());
+      if (!cfd->queued_for_compaction()) {
+        AddToCompactionQueue(cfd);
+        unscheduled_compactions_++;
+      }
+    }
+    ROCKS_LOG_BUFFER(&log_buffer_info,
+                     "[%s] ZNS GC: SSTs total marked = %" PRIu64
+                     ", new marked = %" PRIu64 ", file count: %" PRIu64,
+                     cfd->GetName().c_str(), old_mark_count, new_mark_count,
+                     total_count);
+  }
+  if (unscheduled_compactions_ > 0) {
+    MaybeScheduleFlushOrCompaction();
+  }
+  mutex_.Unlock();
+  log_buffer_info.FlushBufferToLog();
+  log_buffer_debug.FlushBufferToLog();
+}
+#endif
+
 void DBImpl::DumpStats() {
   TEST_SYNC_POINT("DBImpl::DumpStats:1");
 #ifndef ROCKSDB_LITE

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -996,26 +996,41 @@ void DBImpl::ScheduleZNSGC() {
 
   chash_set<uint64_t> mark_for_gc;
 
+  if (initial_db_options_.zenfs_gc_ratio <= 0.0 ||
+      initial_db_options_.zenfs_gc_ratio >= 1.0) {
+    // GC is not enabled
+    return;
+  }
+
   // pick files for GC
   auto stat = GetStat(env_);
 
   uint64_t number;
   FileType type;
 
-  for (auto&& zone : stat) {
+  for (const auto& zone : stat) {
     std::vector<uint64_t> sst_in_zone;
     uint64_t written_data = zone.write_position - zone.start_position;
     // zone is full
     if (written_data == zone.total_capacity) {
       uint64_t total_size = 0;
       bool ignore_zone = false;
-      for (auto&& file : zone.files) {
+      for (const auto& file : zone.files) {
         std::string strip_filename;
 
-        for (auto&& path : immutable_db_options_.db_paths) {
+        for (const auto& path : immutable_db_options_.db_paths) {
           if (Slice(file.filename).starts_with(path.path)) {
             strip_filename = file.filename.substr(path.path.length());
             break;
+          }
+        }
+
+        if (strip_filename.empty()) {
+          for (const auto& path : initial_db_options_.cf_paths) {
+            if (Slice(file.filename).starts_with(path.path)) {
+              strip_filename = file.filename.substr(path.path.length());
+              break;
+            }
           }
         }
 
@@ -1051,7 +1066,8 @@ void DBImpl::ScheduleZNSGC() {
       }
 
       // if data in zone <= (1 - ratio) * total_capacity, recycle the zone
-      if (total_size <= (1.0 - initial_db_options_.zenfs_gc_ratio) * written_data) {
+      if (total_size <=
+          (1.0 - initial_db_options_.zenfs_gc_ratio) * written_data) {
         for (auto&& file_id : sst_in_zone) {
           mark_for_gc.insert(file_id);
         }

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1002,21 +1002,28 @@ void DBImpl::ScheduleZNSGC() {
     return;
   }
 
-  // pick files for GC
+  // Pick files for GC
   auto stat = GetStat(env_);
 
   uint64_t number;
   FileType type;
 
-  std::vector<DbPath> cf_db_paths;
+  // Merge db paths and column family paths together
+  std::set<std::string> db_paths;
 
+  // Get column family paths
   mutex_.Lock();
   for (auto cfd : *versions_->GetColumnFamilySet()) {
     for (const auto& path : cfd->ioptions()->db_paths) {
-      cf_db_paths.emplace_back(path);
+      db_paths.emplace(path.path);
     }
   }
   mutex_.Unlock();
+
+  // Get database paths
+  for (const auto& path : immutable_db_options_.db_paths) {
+    db_paths.emplace(path.path);
+  }
 
   for (const auto& zone : stat) {
     std::vector<uint64_t> sst_in_zone;
@@ -1028,19 +1035,10 @@ void DBImpl::ScheduleZNSGC() {
       for (const auto& file : zone.files) {
         std::string strip_filename;
 
-        for (const auto& path : immutable_db_options_.db_paths) {
+        for (const auto& path : db_paths) {
           if (Slice(file.filename).starts_with(path.path)) {
             strip_filename = file.filename.substr(path.path.length());
             break;
-          }
-        }
-
-        if (strip_filename.empty()) {
-          for (const auto& path : cf_db_paths) {
-            if (Slice(file.filename).starts_with(path.path)) {
-              strip_filename = file.filename.substr(path.path.length());
-              break;
-            }
           }
         }
 

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1008,6 +1008,16 @@ void DBImpl::ScheduleZNSGC() {
   uint64_t number;
   FileType type;
 
+  std::vector<DbPath> cf_db_paths;
+
+  mutex_.Lock();
+  for (auto cfd : *versions_->GetColumnFamilySet()) {
+    for (const auto& path : cfd->ioptions()->db_paths) {
+      cf_db_paths.emplace_back(path);
+    }
+  }
+  mutex_.Unlock();
+
   for (const auto& zone : stat) {
     std::vector<uint64_t> sst_in_zone;
     uint64_t written_data = zone.write_position - zone.start_position;
@@ -1026,7 +1036,7 @@ void DBImpl::ScheduleZNSGC() {
         }
 
         if (strip_filename.empty()) {
-          for (const auto& path : initial_db_options_.cf_paths) {
+          for (const auto& path : cf_db_paths) {
             if (Slice(file.filename).starts_with(path.path)) {
               strip_filename = file.filename.substr(path.path.length());
               break;

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -410,11 +410,11 @@ class DBImpl : public DB {
   // Implemented in db_impl_debug.cc
 
   // Compact any files in the named level that overlap [*begin, *end]
-  Status TEST_CompactRange(int level, const Slice* begin, const Slice* end,
-                           ColumnFamilyHandle* column_family = nullptr,
-                           SeparationType separation_type =
-                               kCompactionTransToSeparate,
-                           bool disallow_trivial_move = false);
+  Status TEST_CompactRange(
+      int level, const Slice* begin, const Slice* end,
+      ColumnFamilyHandle* column_family = nullptr,
+      SeparationType separation_type = kCompactionTransToSeparate,
+      bool disallow_trivial_move = false);
 
   void TEST_SwitchWAL();
 
@@ -805,6 +805,11 @@ class DBImpl : public DB {
   void FlushInfoLog();
 
   void ScheduleTtlGC();
+
+#ifdef LIBZBD
+  // schedule GC by polling ZNS zone status
+  void ScheduleZNSGC();
+#endif
 
  protected:
   Env* const env_;

--- a/db/db_impl_files.cc
+++ b/db/db_impl_files.cc
@@ -532,6 +532,22 @@ void DBImpl::PurgeObsoleteFiles(JobContext& state, bool schedule_only) {
               to_delete;
     }
 
+    // TODO: Workaround for ZNS and Windows.
+    // In TerarkDB, when a WAL is not needed, it is first deleted, and then
+    // closed. This means that the underlying FS must support deferred delete.
+    // In this case, we delete the writer before issuing delete to FS.
+    if (type == kLogFile) {
+      auto it =
+          std::find_if(state.logs_to_free.begin(), state.logs_to_free.end(),
+                       [number](log::Writer* writer) {
+                         return writer->get_log_number() == number;
+                       });
+      if (it != state.logs_to_free.end()) {
+        delete *it;
+        *it = nullptr;
+      }
+    }
+
 #ifndef ROCKSDB_LITE
     if (type == kLogFile && (immutable_db_options_.wal_ttl_seconds > 0 ||
                              immutable_db_options_.wal_size_limit_mb > 0)) {

--- a/db/periodic_work_scheduler.cc
+++ b/db/periodic_work_scheduler.cc
@@ -45,6 +45,13 @@ void PeriodicWorkScheduler::Register(DBImpl* dbi,
              initial_delay.fetch_add(1) % kDefaultScheduleGCTTLPeriodSec *
                  kMicrosInSecond,
              kDefaultScheduleGCTTLPeriodSec * kMicrosInSecond);
+#ifdef LIBZBD
+  timer->Add([dbi]() { dbi->ScheduleZNSGC(); },
+             GetTaskName(dbi, "schedule_gc_zns"),
+             initial_delay.fetch_add(1) % kDefaultScheduleZNSTTLPeriodSec *
+                 kMicrosInSecond,
+             kDefaultScheduleZNSTTLPeriodSec * kMicrosInSecond);
+#endif
 }
 
 void PeriodicWorkScheduler::Unregister(DBImpl* dbi) {
@@ -53,6 +60,9 @@ void PeriodicWorkScheduler::Unregister(DBImpl* dbi) {
   timer->Cancel(GetTaskName(dbi, "pst_st"));
   timer->Cancel(GetTaskName(dbi, "flush_info_log"));
   timer->Cancel(GetTaskName(dbi, "schedule_gc_ttl"));
+#ifdef LIBZBD
+  timer->Cancel(GetTaskName(dbi, "schedule_gc_zns"));
+#endif
   if (!timer->HasPendingTask()) {
     timer->Shutdown();
   }

--- a/db/periodic_work_scheduler.h
+++ b/db/periodic_work_scheduler.h
@@ -41,6 +41,7 @@ class PeriodicWorkScheduler {
   // log.
   static const uint64_t kDefaultFlushInfoLogPeriodSec = 10;
   static const uint64_t kDefaultScheduleGCTTLPeriodSec = 10;
+  static const uint64_t kDefaultScheduleZNSTTLPeriodSec = 10;
 
  protected:
   std::unique_ptr<Timer> timer;

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -28,7 +28,6 @@
 #include "rocksdb/status.h"
 #include "rocksdb/terark_namespace.h"
 #include "rocksdb/thread_status.h"
-#include "third-party/zenfs/fs/zbd_stat.h"
 
 #ifdef _WIN32
 // Windows API macro interference
@@ -1723,7 +1722,4 @@ Status NewZenfsEnv(Env** zenfs_env, const std::string& zdb_path);
 
 Status GetZbdDiskSpaceInfo(Env* env, uint64_t& total_size, uint64_t& avail_size,
                            uint64_t& used_size);
-
-std::vector<ZoneStat> GetStat(Env* env);
-
 }  // namespace TERARKDB_NAMESPACE

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -17,15 +17,18 @@
 #pragma once
 
 #include <stdint.h>
+
 #include <cstdarg>
 #include <functional>
 #include <limits>
 #include <memory>
 #include <string>
 #include <vector>
+
 #include "rocksdb/status.h"
 #include "rocksdb/terark_namespace.h"
 #include "rocksdb/thread_status.h"
+#include "third-party/zenfs/fs/zbd_stat.h"
 
 #ifdef _WIN32
 // Windows API macro interference
@@ -36,7 +39,7 @@
 
 #if defined(__GNUC__) || defined(__clang__)
 #define ROCKSDB_PRINTF_FORMAT_ATTR(format_param, dots_param) \
-    __attribute__((__format__(__printf__, format_param, dots_param)))
+  __attribute__((__format__(__printf__, format_param, dots_param)))
 #else
 #define ROCKSDB_PRINTF_FORMAT_ATTR(format_param, dots_param)
 #endif
@@ -154,7 +157,7 @@ class Env {
   // Loads the environment specified by the input value into the result
   static Status LoadEnv(const std::string& value, Env** result,
                         std::shared_ptr<Env>* guard);
-                        
+
   // Return a default environment suitable for the current operating
   // system.  Sophisticated users may wish to provide their own Env
   // implementation instead of relying on this default environment.
@@ -571,7 +574,6 @@ class Env {
   // could be a fully implemented one, or a wrapper class around the Env
   const std::shared_ptr<FileSystem>& GetFileSystem() const;
 
-
   // If you're adding methods here, remember to add them to EnvWrapper too.
 
  protected:
@@ -761,7 +763,7 @@ class RandomAccessFile {
     assert(false);
     return -1;
   }
-  
+
   // If you're adding methods here, remember to add them to
   // RandomAccessFileWrapper too.
 };
@@ -1553,6 +1555,7 @@ class RandomAccessFileWrapper : public RandomAccessFile {
   virtual intptr_t FileDescriptor() const override {
     return target_->FileDescriptor();
   }
+
  private:
   RandomAccessFile* target_;
 };
@@ -1718,6 +1721,9 @@ Env* NewTimedEnv(Env* base_env);
 
 Status NewZenfsEnv(Env** zenfs_env, const std::string& zdb_path);
 
-Status GetZbdDiskSpaceInfo(Env* env, uint64_t &total_size, uint64_t &avail_size, uint64_t &used_size);
+Status GetZbdDiskSpaceInfo(Env* env, uint64_t& total_size, uint64_t& avail_size,
+                           uint64_t& used_size);
+
+std::vector<ZoneStat> GetStat(Env* env);
 
 }  // namespace TERARKDB_NAMESPACE

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1095,8 +1095,8 @@ struct DBOptions {
 
   // If ZenFS reports a full zone contains more garbage than
   // this ratio, a compaction job on this zone will be submitted.
-  // This option is not recommended to be used with lazy compaction and multiple
-  // cf paths. At the same time, zone size * gc ratio should be less than zone
+  // This option is not recommended to be used with lazy compaction.
+  // At the same time, zone size * gc ratio should be less than zone
   // size minus single SST size, otherwise GC will never take effect.
   // If being set to value <= 0.0 or >= 1.0, ZenFS GC will not run.
   double zenfs_gc_ratio = 0.5;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1099,7 +1099,7 @@ struct DBOptions {
   // At the same time, zone size * gc ratio should be less than zone
   // size minus single SST size, otherwise GC will never take effect.
   // If being set to value <= 0.0 or >= 1.0, ZenFS GC will not run.
-  double zenfs_gc_ratio = 0.5;
+  double zenfs_gc_ratio = 0.25;
 };
 
 // Options to control the behavior of a database (passed to DB::Open)

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1095,7 +1095,10 @@ struct DBOptions {
 
   // If ZenFS reports a full zone contains more garbage than
   // this ratio, a compaction job on this zone will be submitted.
-  // This option is incompatible with lazy compaction.
+  // This option is not recommended to be used with lazy compaction and multiple
+  // cf paths. At the same time, zone size * gc ratio should be less than zone
+  // size minus single SST size, otherwise GC will never take effect.
+  // If being set to value <= 0.0 or >= 1.0, ZenFS GC will not run.
   double zenfs_gc_ratio = 0.5;
 };
 

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1092,6 +1092,11 @@ struct DBOptions {
   // If set to true, takes precedence over
   // ReadOptions::background_purge_on_iterator_cleanup.
   bool avoid_unnecessary_blocking_io = false;
+
+  // If ZenFS reports a full zone contains more garbage than
+  // this ratio, a compaction job on this zone will be submitted.
+  // This option is incompatible with lazy compaction.
+  double zenfs_gc_ratio = 0.5;
 };
 
 // Options to control the behavior of a database (passed to DB::Open)

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -94,6 +94,7 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       manual_wal_flush(options.manual_wal_flush),
       atomic_flush(options.atomic_flush),
       avoid_unnecessary_blocking_io(options.avoid_unnecessary_blocking_io),
+      zenfs_gc_ratio(options.zenfs_gc_ratio),
       persist_stats_to_disk(options.persist_stats_to_disk) {
 }
 
@@ -248,6 +249,8 @@ void ImmutableDBOptions::Dump(Logger* log) const {
                    atomic_flush);
   ROCKS_LOG_HEADER(log, "          Options.avoid_unnecessary_blocking_io: %d",
                    avoid_unnecessary_blocking_io);
+  ROCKS_LOG_HEADER(log, "                         Options.zenfs_gc_ratio: %lf",
+                   zenfs_gc_ratio);
   ROCKS_LOG_HEADER(log, "                Options.persist_stats_to_disk: %u",
                    persist_stats_to_disk);
 }

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -87,6 +87,7 @@ struct ImmutableDBOptions {
   bool manual_wal_flush;
   bool atomic_flush;
   bool avoid_unnecessary_blocking_io;
+  double zenfs_gc_ratio;
   bool persist_stats_to_disk;
 };
 

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -143,7 +143,7 @@ DBOptions BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
   options.atomic_flush = immutable_db_options.atomic_flush;
   options.avoid_unnecessary_blocking_io =
       immutable_db_options.avoid_unnecessary_blocking_io;
-
+  options.zenfs_gc_ratio = immutable_db_options.zenfs_gc_ratio;
   return options;
 }
 
@@ -1783,7 +1783,11 @@ std::unordered_map<std::string, OptionTypeInfo>
         {"avoid_unnecessary_blocking_io",
          {offsetof(struct DBOptions, avoid_unnecessary_blocking_io),
           OptionType::kBoolean, OptionVerificationType::kNormal, false,
-          offsetof(struct ImmutableDBOptions, avoid_unnecessary_blocking_io)}}};
+          offsetof(struct ImmutableDBOptions, avoid_unnecessary_blocking_io)}},
+        {"zenfs_gc_ratio",
+         {offsetof(struct DBOptions, zenfs_gc_ratio),
+          OptionType::kDouble, OptionVerificationType::kNormal, false,
+          offsetof(struct ImmutableDBOptions, zenfs_gc_ratio)}}};
 
 std::unordered_map<std::string, BlockBasedTableOptions::IndexType>
     OptionsHelper::block_base_table_index_type_string_map = {

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -306,7 +306,8 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
                              "manual_wal_flush=false;"
                              "seq_per_batch=false;"
                              "atomic_flush=false;"
-                             "avoid_unnecessary_blocking_io=false",
+                             "avoid_unnecessary_blocking_io=false;"
+                             "zenfs_gc_ratio=0.25"
                              new_options));
 
   ASSERT_EQ(unset_bytes_base, NumUnsetBytes(new_options_ptr, sizeof(DBOptions),

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1172,7 +1172,7 @@ DEFINE_bool(report_file_operations, false,
             "if report number of file "
             "operations");
 
-DEFINE_double(zenfs_gc_ratio, 0.5,
+DEFINE_double(zenfs_gc_ratio, 0.25,
               "When ZenFS support is enabled, a full zone with more than "
               "garbage of this ratio will be recycled. This options is "
               "not recommended to be used with lazy compaction. At the "

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1175,7 +1175,9 @@ DEFINE_bool(report_file_operations, false,
 DEFINE_double(zenfs_gc_ratio, 0.5,
               "When ZenFS support is enabled, a full zone with more than "
               "garbage of this ratio will be recycled. This options is "
-              "incompatible with lazy compaction");
+              "not recommended to be used with lazy compaction, multiple"
+              "cf paths, and zone size * gc ratio should be less than"
+              "zone size minus single SST size.");
 
 static const bool FLAGS_soft_rate_limit_dummy __attribute__((__unused__)) =
     RegisterFlagValidator(&FLAGS_soft_rate_limit, &ValidateRateLimit);

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1175,8 +1175,8 @@ DEFINE_bool(report_file_operations, false,
 DEFINE_double(zenfs_gc_ratio, 0.5,
               "When ZenFS support is enabled, a full zone with more than "
               "garbage of this ratio will be recycled. This options is "
-              "not recommended to be used with lazy compaction, multiple"
-              "cf paths, and zone size * gc ratio should be less than"
+              "not recommended to be used with lazy compaction. At the "
+              "same time, zone size * gc ratio should be less than "
               "zone size minus single SST size.");
 
 static const bool FLAGS_soft_rate_limit_dummy __attribute__((__unused__)) =

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1172,6 +1172,11 @@ DEFINE_bool(report_file_operations, false,
             "if report number of file "
             "operations");
 
+DEFINE_double(zenfs_gc_ratio, 0.5,
+              "When ZenFS support is enabled, a full zone with more than "
+              "garbage of this ratio will be recycled. This options is "
+              "incompatible with lazy compaction");
+
 static const bool FLAGS_soft_rate_limit_dummy __attribute__((__unused__)) =
     RegisterFlagValidator(&FLAGS_soft_rate_limit, &ValidateRateLimit);
 
@@ -3250,6 +3255,7 @@ class Benchmark {
     options.use_direct_io_for_flush_and_compaction =
         FLAGS_use_direct_io_for_flush_and_compaction;
     options.use_aio_reads = FLAGS_use_aio_reads;
+    options.zenfs_gc_ratio = FLAGS_zenfs_gc_ratio;
     if (FLAGS_prefix_size != 0) {
       options.prefix_extractor.reset(
           NewFixedPrefixTransform(FLAGS_prefix_size));


### PR DESCRIPTION
This PR adds GC for ZNS. Here's how it works:

* We use the statistics interface added in https://github.com/bzbd/zenfs/pull/6, where we can get what size each file occupies in each zone.
* We spawn a ZNSGC task in the background, which works like TTLGC. It polls statistics from ZenFS every 10s.
* The task will find all full zones with 50% garbage (by default) and mark files in that zone for GC.

Along with ZNS GC, other features are added.

* We added `zenfs_gc_ratio` option in db_bench command.
* We fixed a bug where files may be deleted before closed.

Signed-off-by: Alex Chi <iskyzh@gmail.com>