### PR TITLE
Fix db_properties_test and db_wal_test

### DIFF
--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -441,6 +441,8 @@ Options DBTestBase::GetOptions(
       break;
     case kDBLogDir:
       options.db_log_dir = alternative_db_log_dir_;
+      env_->CreateDirIfMissing(options.db_log_dir);
+      CreateLoggerFromOptions(dbname_, options, &options.info_log);
       break;
     case kWalDirAndMmapReads:
       options.wal_dir = alternative_wal_dir_;


### PR DESCRIPTION
Fix #85.

I am investigating `db_properties_test` at first, but this fix works for `db_wal_test` as well. 

```
99% tests passed, 2 tests failed out of 152

Total Test time (real) = 1536.79 sec

The following tests FAILED:
          3 - column_family_test (Child aborted)
         16 - db_compaction_test (Failed)
```

---
### Analysis

`DBPropertiesTest` gets SegFault because `options.info_log` is not initialized when we are in `KDBLogDir` OptionConfig.
```
0x000055555577bb50 in terarkdb::EventLogger::GetInfoLogLevel (this=0x7ffff6307518) at <workpath>/terarkdb/util/event_logger.h:184
184       InfoLogLevel GetInfoLogLevel() const { return logger_->GetInfoLogLevel(); }  # logger_ == nullptr here
```

Therefore, I create `db_log_dir`&`info_log` if needed for `KDBLogDir` case.

