### PR TITLE
Fix ColumnFamilyTest.BulkAddDrop

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -2052,7 +2052,7 @@ Status DBImpl::CreateColumnFamilies(
   autovector<Status> s_list = CreateColumnFamilyImpl(
       cf_options_list, column_family_name_list, handle_list);
   int success_count = std::count_if(s_list.begin(), s_list.end(),
-                                     [](const Status& s) { return s.ok(); });
+                                    [](const Status& s) { return s.ok(); });
   Status s;
   if (success_count > 0) {
     Status persist_options_status = WriteOptionsFile(
@@ -2091,7 +2091,7 @@ Status DBImpl::CreateColumnFamilies(
   autovector<Status> s_list = CreateColumnFamilyImpl(
       cf_options_list, column_family_name_list, handle_list);
   int success_count = std::count_if(s_list.begin(), s_list.end(),
-                                     [](const Status& s) { return s.ok(); });
+                                    [](const Status& s) { return s.ok(); });
   Status s;
   if (success_count > 0) {
     Status persist_options_status = WriteOptionsFile(


### PR DESCRIPTION
Fix #85 .

```
$ ./column_family_test
[==========] Running 102 tests from 4 test cases.
[----------] Global test environment set-up.
[----------] 47 tests from FormatDef/ColumnFamilyTest
[ RUN      ] FormatDef/ColumnFamilyTest.DontReuseColumnFamilyID/0
...
[----------] 4 tests from FormatLatest/FlushEmptyCFTestWithParam (161 ms total)

[----------] Global test environment tear-down
[==========] 102 tests from 4 test cases ran. (29366 ms total)
[  PASSED  ] 102 tests.
```

Not an expert on c++, but I think there is some memory issues in the currect bulk CreateColumnFamilyImpl.
```
valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --verbose --log-file=valgrind-out.txt ./column_family_test --gtest_filter=FormatDef/ColumnFamilyTest.BulkAddDrop*
```

Example that simulates the change of behaviors in this pr
```
void test_vectorp() {
  autovector<double*> array;
  auto cleanup_func = [&]() {
    for (const auto& e : array) {
      delete e;
    }
  };
  int lmt = 100;
  // for (int i = 0; i < lmt; ++i) {
  //   double* pd = new double(1);  // ok, but need to clean up
  //   array.emplace_back(pd);
  // }
  std::vector<double> vd;
  for (int i = 0; i < lmt; ++i) {
    vd.emplace_back();  // bad: heap-use-after-scope
    array.emplace_back(&vd.back());
  }
  double sum = 0;
  for (const auto& e : array) {
    sum += *e;
  }
  cleanup_func();
  std::cout << sum << std::endl;
}
```

Not a big fan of raw pointer (new) either, we might replace it with `autovector<std::unique_ptr>` (which might need to change some interfaces though), open to discuss.
