### PR TITLE
add ZenFS tracing facilities

### DIFF
--- a/env/env_zenfs.cc
+++ b/env/env_zenfs.cc
@@ -181,8 +181,10 @@ class ZenfsEnv : public EnvWrapper {
   // Initialize an EnvWrapper that delegates all calls to *t
   explicit ZenfsEnv(Env* t) : EnvWrapper(t), target_(t) {}
 
-  Status InitZenfs(const std::string& zdb_path) {
-    return NewZenFS(&fs_, zdb_path);
+  Status InitZenfs(
+      const std::string& zdb_path, std::string bytedance_tags_,
+      std::shared_ptr<MetricsReporterFactory> metrics_reporter_factory_) {
+    return NewZenFS(&fs_, zdb_path, bytedance_tags_, metrics_reporter_factory_);
   }
 
   // Return the target to which this Env forwards all calls
@@ -487,10 +489,13 @@ class ZenfsEnv : public EnvWrapper {
   FileSystem* fs_;
 };
 
-Status NewZenfsEnv(Env** zenfs_env, const std::string& zdb_path) {
+Status NewZenfsEnv(
+    Env** zenfs_env, const std::string& zdb_path, std::string bytedance_tags_,
+    std::shared_ptr<MetricsReporterFactory> metrics_reporter_factory_) {
   assert(zdb_path.length() > 0);
   auto env = new ZenfsEnv(Env::Default());
-  Status s = env->InitZenfs(zdb_path);
+  Status s =
+      env->InitZenfs(zdb_path, bytedance_tags_, metrics_reporter_factory_);
   *zenfs_env = s.ok() ? env : nullptr;
   return s;
 }
@@ -513,7 +518,9 @@ std::vector<ZoneStat> GetStat(Env* env) {
 
 namespace TERARKDB_NAMESPACE {
 
-Status NewZenfsEnv(Env** zenfs_env, const std::string& zdb_path) {
+Status NewZenfsEnv(
+    Env** zenfs_env, const std::string& zdb_path, std::string bytedance_tags_,
+    std::shared_ptr<MetricsReporterFactory> metrics_reporter_factory_) {
   *zenfs_env = nullptr;
   return Status::NotSupported("ZenFSEnv is not implemented.");
 }

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -1718,7 +1718,11 @@ Status NewHdfsEnv(Env** hdfs_env, const std::string& fsname);
 // This is a factory method for TimedEnv defined in utilities/env_timed.cc.
 Env* NewTimedEnv(Env* base_env);
 
-Status NewZenfsEnv(Env** zenfs_env, const std::string& zdb_path);
+class MetricsReporterFactory;
+
+Status NewZenfsEnv(
+    Env** zenfs_env, const std::string& zdb_path, std::string bytedance_tags_,
+    std::shared_ptr<MetricsReporterFactory> metrics_reporter_factory_);
 
 Status GetZbdDiskSpaceInfo(Env* env, uint64_t& total_size, uint64_t& avail_size,
                            uint64_t& used_size);

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -77,6 +77,7 @@
 #include "utilities/merge_operators.h"
 #include "utilities/merge_operators/bytesxor.h"
 #include "utilities/persistent_cache/block_cache_tier.h"
+#include "utilities/trace/bytedance_metrics_reporter.h"
 
 #ifdef OS_WIN
 #include <io.h>  // open/close
@@ -5859,7 +5860,7 @@ int db_bench_tool(int argc, char** argv) {
   } 
   #ifdef LIBZBD
     else if (!FLAGS_zbd_path.empty()) {
-      Status s = NewZenfsEnv(&FLAGS_env, FLAGS_zbd_path);
+      Status s = NewZenfsEnv(&FLAGS_env, FLAGS_zbd_path, "db_bench", std::make_shared<ByteDanceMetricsReporterFactory>());
       if (!s.ok()) {
         fprintf(stderr, "Error: Init zenfs env failed.\nStatus : %s\n", s.ToString().c_str());
         exit(1);

--- a/utilities/trace/bytedance_metrics_reporter.h
+++ b/utilities/trace/bytedance_metrics_reporter.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <atomic>
 #include <chrono>
 #include <list>


### PR DESCRIPTION
This PR adapts TerarkDB to ZenFS tracing. Note that now `NewZenFSEnv` requires two new parameters.

Related PR: https://github.com/bzbd/zenfs/pull/12

Signed-off-by: Alex Chi <iskyzh@gmail.com>