### PR TITLE
fix negative lifetime hint

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1284,6 +1284,9 @@ Env::WriteLifeTimeHint ColumnFamilyData::CalculateSSTWriteHint(int level) {
   if (level - base_level >= 2) {
     return Env::WLTH_EXTREME;
   }
+
+  int hint = level - base_level + static_cast<int>(Env::WLTH_MEDIUM);
+  if (hint < 0) return Env::WLTH_NOT_SET;
   return static_cast<Env::WriteLifeTimeHint>(
       level - base_level + static_cast<int>(Env::WLTH_MEDIUM));
 }


### PR DESCRIPTION
Lifetime hint could be negative in TerarkDB. This would pose issue for ZenFS. In this PR, we fixed this.