### PR TITLE
Add GroupAtomicFlush support

### DIFF
--- a/db/compaction.cc
+++ b/db/compaction.cc
@@ -202,12 +202,12 @@ void ProcessFileMetaData(const char* job_info, FileMetaData* meta,
     GetCompactionTimePoint(tp->user_collected_properties,
                            &meta->prop.earliest_time_begin_compact,
                            &meta->prop.latest_time_end_compact);
+    ROCKS_LOG_INFO(iopt->info_log,
+                   "%s earliest_time_begin_compact = %" PRIu64
+                   ", latest_time_end_compact = %" PRIu64,
+                   job_info, meta->prop.earliest_time_begin_compact,
+                   meta->prop.latest_time_end_compact);
   }
-  ROCKS_LOG_INFO(iopt->info_log,
-                 "%s earliest_time_begin_compact = %" PRIu64
-                 ", latest_time_end_compact = %" PRIu64,
-                 job_info, meta->prop.earliest_time_begin_compact,
-                 meta->prop.latest_time_end_compact);
 }
 
 void Compaction::SetInputVersion(Version* _input_version) {

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -448,7 +448,7 @@ TEST_P(DBAtomicFlushTest,
   SyncPoint::GetInstance()->DisableProcessing();
   SyncPoint::GetInstance()->ClearAllCallBacks();
   SyncPoint::GetInstance()->LoadDependency(
-      {{"DBImpl::AtomicFlushMemTables:AfterScheduleFlush",
+      {{"DBImpl::FlushMemTable:AfterScheduleFlush",
         "DBAtomicFlushTest::BeforeDropCF"},
        {"DBAtomicFlushTest::AfterDropCF",
         "DBImpl::BackgroundCallFlush:start"}});

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -291,7 +291,7 @@ TEST_F(DBFlushTest, ManualFlushFailsInReadOnlyMode) {
 TEST_P(DBAtomicFlushTest, ManualAtomicFlush) {
   Options options = CurrentOptions();
   options.create_if_missing = true;
-  options.atomic_flush = GetParam();
+  options.atomic_flush_group = NewAtomicFlushGroup();
   options.write_buffer_size = (static_cast<size_t>(64) << 20);
 
   CreateAndReopenWithCF({"pikachu", "eevee"}, options);
@@ -317,7 +317,7 @@ TEST_P(DBAtomicFlushTest, ManualAtomicFlush) {
 TEST_P(DBAtomicFlushTest, AtomicFlushTriggeredByMemTableFull) {
   Options options = CurrentOptions();
   options.create_if_missing = true;
-  options.atomic_flush = GetParam();
+  options.atomic_flush_group = NewAtomicFlushGroup();
   // 4KB so that we can easily trigger auto flush.
   options.write_buffer_size = 4096;
 
@@ -343,7 +343,7 @@ TEST_P(DBAtomicFlushTest, AtomicFlushTriggeredByMemTableFull) {
 
   TEST_SYNC_POINT(
       "DBAtomicFlushTest::AtomicFlushTriggeredByMemTableFull:BeforeCheck");
-  if (options.atomic_flush) {
+  if (options.atomic_flush_group != nullptr) {
     for (size_t i = 0; i != num_cfs - 1; ++i) {
       auto cfh = static_cast<ColumnFamilyHandleImpl*>(handles_[i]);
       ASSERT_EQ(0, cfh->cfd()->imm()->NumNotFlushed());
@@ -368,7 +368,7 @@ TEST_P(DBAtomicFlushTest, AtomicFlushRollbackSomeJobs) {
       new FaultInjectionTestEnv(env_));
   Options options = CurrentOptions();
   options.create_if_missing = true;
-  options.atomic_flush = atomic_flush;
+  options.atomic_flush_group = NewAtomicFlushGroup();
   options.env = fault_injection_env.get();
   SyncPoint::GetInstance()->DisableProcessing();
   SyncPoint::GetInstance()->LoadDependency(
@@ -412,7 +412,7 @@ TEST_P(DBAtomicFlushTest, FlushMultipleCFs_DropSomeBeforeRequestFlush) {
   }
   Options options = CurrentOptions();
   options.create_if_missing = true;
-  options.atomic_flush = atomic_flush;
+  options.atomic_flush_group = NewAtomicFlushGroup();
   SyncPoint::GetInstance()->DisableProcessing();
   SyncPoint::GetInstance()->ClearAllCallBacks();
   SyncPoint::GetInstance()->EnableProcessing();
@@ -441,7 +441,7 @@ TEST_P(DBAtomicFlushTest,
   }
   Options options = CurrentOptions();
   options.create_if_missing = true;
-  options.atomic_flush = atomic_flush;
+  options.atomic_flush_group = NewAtomicFlushGroup();
 
   CreateAndReopenWithCF({"pikachu", "eevee"}, options);
 

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -419,26 +419,19 @@ Status DBImpl::ResumeImpl() {
     FlushOptions flush_opts;
     // We allow flush to stall write since we are trying to resume from error.
     flush_opts.allow_write_stall = true;
-    if (immutable_db_options_.atomic_flush) {
-      autovector<ColumnFamilyData*> cfds;
-      SelectColumnFamiliesForAtomicFlush(&cfds);
-      mutex_.Unlock();
-      s = AtomicFlushMemTables(cfds, flush_opts, FlushReason::kErrorRecovery);
-      mutex_.Lock();
-    } else {
-      for (auto cfd : *versions_->GetColumnFamilySet()) {
-        if (cfd->IsDropped()) {
-          continue;
-        }
-        cfd->Ref();
-        mutex_.Unlock();
-        s = FlushMemTable(cfd, flush_opts, FlushReason::kErrorRecovery);
-        mutex_.Lock();
-        cfd->Unref();
-        if (!s.ok()) {
-          break;
-        }
+    autovector<ColumnFamilyData*> cfds;
+    for (auto cfd : *versions_->GetColumnFamilySet()) {
+      if (cfd->IsDropped()) {
+        continue;
       }
+      cfd->Ref();
+      cfds.push_back(cfd);
+    }
+    mutex_.Unlock();
+    s = FlushMemTable(cfds, flush_opts, FlushReason::kErrorRecovery);
+    mutex_.Lock();
+    for (auto cfd : cfds) {
+      cfd->Unref();
     }
     if (!s.ok()) {
       ROCKS_LOG_INFO(immutable_db_options_.info_log,
@@ -508,22 +501,19 @@ void DBImpl::CancelAllBackgroundWork(bool wait) {
   if (!shutting_down_.load(std::memory_order_acquire) &&
       has_unpersisted_data_.load(std::memory_order_relaxed) &&
       !mutable_db_options_.avoid_flush_during_shutdown) {
-    if (immutable_db_options_.atomic_flush) {
-      autovector<ColumnFamilyData*> cfds;
-      SelectColumnFamiliesForAtomicFlush(&cfds);
-      mutex_.Unlock();
-      AtomicFlushMemTables(cfds, FlushOptions(), FlushReason::kShutDown);
-      mutex_.Lock();
-    } else {
-      for (auto cfd : *versions_->GetColumnFamilySet()) {
-        if (!cfd->IsDropped() && cfd->initialized() && !cfd->mem()->IsEmpty()) {
-          cfd->Ref();
-          mutex_.Unlock();
-          FlushMemTable(cfd, FlushOptions(), FlushReason::kShutDown);
-          mutex_.Lock();
-          cfd->Unref();
-        }
+    autovector<ColumnFamilyData*> cfds;
+    for (auto cfd : *versions_->GetColumnFamilySet()) {
+      if (cfd->IsDropped()) {
+        continue;
       }
+      cfd->Ref();
+      cfds.push_back(cfd);
+    }
+    mutex_.Unlock();
+    FlushMemTable(cfds, FlushOptions(), FlushReason::kShutDown);
+    mutex_.Lock();
+    for (auto cfd : cfds) {
+      cfd->Unref();
     }
     versions_->GetColumnFamilySet()->FreeDeadColumnFamilies();
   }
@@ -4216,19 +4206,10 @@ Status DBImpl::IngestExternalFile(
       if (status.ok() && need_flush) {
         FlushOptions flush_opts;
         flush_opts.allow_write_stall = true;
-        if (immutable_db_options_.atomic_flush) {
-          autovector<ColumnFamilyData*> cfds;
-          SelectColumnFamiliesForAtomicFlush(&cfds);
-          mutex_.Unlock();
-          status = AtomicFlushMemTables(cfds, flush_opts,
-                                        FlushReason::kExternalFileIngestion,
-                                        true /* writes_stopped */);
-        } else {
-          mutex_.Unlock();
-          status = FlushMemTable(cfd, flush_opts,
-                                 FlushReason::kExternalFileIngestion,
-                                 true /* writes_stopped */);
-        }
+        mutex_.Unlock();
+        status = FlushMemTable({cfd}, flush_opts,
+                               FlushReason::kExternalFileIngestion,
+                               true /* writes_stopped */);
         mutex_.Lock();
       }
     }

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -1220,11 +1220,11 @@ class DBImpl : public DB {
   typedef autovector<FlushRequest> FlushRequestVec;
 
   // process atomic flush group
-  void GenerateFlushRequest(autovector<ColumnFamilyData*>* cfds,
-                            FlushRequestVec* req);
+  void ProcessAtomicFlushGroup(autovector<ColumnFamilyData*>* cfds,
+                               FlushRequestVec* req);
 
   // REQUIRES: mutex locked and in write thread.
-  void AssignAtomicFlushSeq(const FlushRequestVec& req);
+  void PrepareFlushReqVec(FlushRequestVec& req);
 
   void SchedulePendingFlush(const FlushRequestVec& req,
                             FlushReason flush_reason);

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -1128,16 +1128,10 @@ class DBImpl : public DB {
 
   Status SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context);
 
-  void SelectColumnFamiliesForAtomicFlush(autovector<ColumnFamilyData*>* cfds);
-
   // Force current memtable contents to be flushed.
-  Status FlushMemTable(ColumnFamilyData* cfd, const FlushOptions& options,
-                       FlushReason flush_reason, bool writes_stopped = false);
-
-  Status AtomicFlushMemTables(
-      const autovector<ColumnFamilyData*>& column_family_datas,
-      const FlushOptions& options, FlushReason flush_reason,
-      bool writes_stopped = false);
+  Status FlushMemTable(const autovector<ColumnFamilyData*>& column_family_datas,
+                       const FlushOptions& options, FlushReason flush_reason,
+                       bool writes_stopped = false);
 
   // Wait until flushing this column family won't stall writes
   Status WaitUntilFlushWouldNotStallWrites(ColumnFamilyData* cfd,
@@ -1160,9 +1154,6 @@ class DBImpl : public DB {
       const autovector<ColumnFamilyData*>& cfds,
       const autovector<const uint64_t*>& flush_memtable_ids,
       bool resuming_from_bg_err);
-
-  // REQUIRES: mutex locked and in write thread.
-  void AssignAtomicFlushSeq(const autovector<ColumnFamilyData*>& cfds);
 
   // REQUIRES: mutex locked
   Status SwitchWAL(WriteContext* write_context);
@@ -1225,12 +1216,18 @@ class DBImpl : public DB {
   // specified value, this flush request is considered to have completed its
   // work of flushing this column family. After completing the work for all
   // column families in this request, this flush is considered complete.
-  typedef std::vector<std::pair<ColumnFamilyData*, uint64_t>> FlushRequest;
+  typedef autovector<std::pair<ColumnFamilyData*, uint64_t>> FlushRequest;
+  typedef autovector<FlushRequest> FlushRequestVec;
 
-  void GenerateFlushRequest(const autovector<ColumnFamilyData*>& cfds,
-                            FlushRequest* req);
+  // process atomic flush group
+  void GenerateFlushRequest(autovector<ColumnFamilyData*>* cfds,
+                            FlushRequestVec* req);
 
-  void SchedulePendingFlush(const FlushRequest& req, FlushReason flush_reason);
+  // REQUIRES: mutex locked and in write thread.
+  void AssignAtomicFlushSeq(const FlushRequestVec& req);
+
+  void SchedulePendingFlush(const FlushRequestVec& req,
+                            FlushReason flush_reason);
   void SchedulePendingCompaction(ColumnFamilyData* cfd);
   void SchedulePendingGarbageCollection(ColumnFamilyData* cfd);
   void SchedulePendingPurge(const std::string& fname,

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -1224,7 +1224,7 @@ class DBImpl : public DB {
                                FlushRequestVec* req);
 
   // REQUIRES: mutex locked and in write thread.
-  void PrepareFlushReqVec(FlushRequestVec& req);
+  void PrepareFlushReqVec(FlushRequestVec& req, bool force_flush);
 
   void SchedulePendingFlush(const FlushRequestVec& req,
                             FlushReason flush_reason);

--- a/db/db_impl_debug.cc
+++ b/db/db_impl_debug.cc
@@ -120,7 +120,7 @@ Status DBImpl::TEST_FlushMemTable(bool wait, bool allow_write_stall,
     auto cfhi = reinterpret_cast<ColumnFamilyHandleImpl*>(cfh);
     cfd = cfhi->cfd();
   }
-  return FlushMemTable(cfd, fo, FlushReason::kTest);
+  return FlushMemTable({cfd}, fo, FlushReason::kTest);
 }
 
 Status DBImpl::TEST_WaitForFlushMemTable(ColumnFamilyHandle* column_family) {

--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -1028,28 +1028,6 @@ Status DBImpl::WriteRecoverableState() {
   return Status::OK();
 }
 
-void DBImpl::SelectColumnFamiliesForAtomicFlush(
-    autovector<ColumnFamilyData*>* cfds) {
-  for (ColumnFamilyData* cfd : *versions_->GetColumnFamilySet()) {
-    if (cfd->IsDropped()) {
-      continue;
-    }
-    if (cfd->imm()->NumNotFlushed() != 0 || !cfd->mem()->IsEmpty() ||
-        !cached_recoverable_state_empty_.load()) {
-      cfds->push_back(cfd);
-    }
-  }
-}
-
-// Assign sequence number for atomic flush.
-void DBImpl::AssignAtomicFlushSeq(const autovector<ColumnFamilyData*>& cfds) {
-  assert(immutable_db_options_.atomic_flush);
-  auto seq = versions_->LastSequence();
-  for (auto cfd : cfds) {
-    cfd->imm()->AssignAtomicFlushSeq(seq);
-  }
-}
-
 Status DBImpl::SwitchWAL(WriteContext* write_context) {
   mutex_.AssertHeld();
   assert(write_context != nullptr);
@@ -1095,18 +1073,16 @@ Status DBImpl::SwitchWAL(WriteContext* write_context) {
   // no need to refcount because drop is happening in write thread, so can't
   // happen while we're in the write thread
   autovector<ColumnFamilyData*> cfds;
-  if (immutable_db_options_.atomic_flush) {
-    SelectColumnFamiliesForAtomicFlush(&cfds);
-  } else {
-    for (auto cfd : *versions_->GetColumnFamilySet()) {
-      if (cfd->IsDropped()) {
-        continue;
-      }
-      if (cfd->OldestLogToKeep() <= oldest_alive_log) {
-        cfds.push_back(cfd);
-      }
+  for (auto cfd : *versions_->GetColumnFamilySet()) {
+    if (cfd->IsDropped()) {
+      continue;
+    }
+    if (cfd->OldestLogToKeep() <= oldest_alive_log) {
+      cfds.push_back(cfd);
     }
   }
+  FlushRequestVec flush_req_vec;
+  GenerateFlushRequest(&cfds, &flush_req_vec);
   uint64_t total_log_size = total_log_size_.load();
   uint64_t max_total_wal_size = GetMaxTotalWalSize();
   for (const auto cfd : cfds) {
@@ -1125,15 +1101,8 @@ Status DBImpl::SwitchWAL(WriteContext* write_context) {
     }
   }
   if (status.ok()) {
-    if (immutable_db_options_.atomic_flush) {
-      AssignAtomicFlushSeq(cfds);
-    }
-    for (auto cfd : cfds) {
-      cfd->imm()->FlushRequested();
-    }
-    FlushRequest flush_req;
-    GenerateFlushRequest(cfds, &flush_req);
-    SchedulePendingFlush(flush_req, FlushReason::kWriteBufferManager);
+    AssignAtomicFlushSeq(flush_req_vec);
+    SchedulePendingFlush(flush_req_vec, FlushReason::kWriteBufferManager);
     MaybeScheduleFlushOrCompaction();
   }
   return status;
@@ -1162,40 +1131,38 @@ Status DBImpl::HandleWriteBufferFull(WriteContext* write_context) {
   // no need to refcount because drop is happening in write thread, so can't
   // happen while we're in the write thread
   autovector<ColumnFamilyData*> cfds;
-  if (immutable_db_options_.atomic_flush) {
-    SelectColumnFamiliesForAtomicFlush(&cfds);
-  } else {
-    ColumnFamilyData* cfd_picked = nullptr;
-    SequenceNumber seq_num_for_cf_picked = kMaxSequenceNumber;
-    size_t largest_cfd_size = 0;
+  FlushRequestVec flush_req_vec;
+  ColumnFamilyData* cfd_picked = nullptr;
+  SequenceNumber seq_num_for_cf_picked = kMaxSequenceNumber;
+  size_t largest_cfd_size = 0;
 
-    for (auto cfd : *versions_->GetColumnFamilySet()) {
-      if (cfd->IsDropped()) {
-        continue;
-      }
-      if (!cfd->mem()->IsEmpty()) {
-        // We only consider active mem table, hoping immutable memtable is
-        // already in the process of flushing.
-        if (flush_pri == kFlushOldest) {
-          uint64_t seq = cfd->mem()->GetCreationSeq();
-          if (cfd_picked == nullptr || seq < seq_num_for_cf_picked) {
-            cfd_picked = cfd;
-            seq_num_for_cf_picked = seq;
-          }
-        } else if (!cfd->queued_for_flush()) {
-          assert(flush_pri == kFlushLargest);
-          size_t cfd_size = cfd->mem()->ApproximateMemoryUsage();
-          if (cfd_picked == nullptr || cfd_size > largest_cfd_size) {
-            cfd_picked = cfd;
-            largest_cfd_size = cfd_size;
-          }
+  for (auto cfd : *versions_->GetColumnFamilySet()) {
+    if (cfd->IsDropped()) {
+      continue;
+    }
+    if (!cfd->mem()->IsEmpty()) {
+      // We only consider active mem table, hoping immutable memtable is already
+      // in the process of flushing.
+      if (flush_pri == kFlushOldest) {
+        uint64_t seq = cfd->mem()->GetCreationSeq();
+        if (cfd_picked == nullptr || seq < seq_num_for_cf_picked) {
+          cfd_picked = cfd;
+          seq_num_for_cf_picked = seq;
+        }
+      } else if (!cfd->queued_for_flush()) {
+        assert(flush_pri == kFlushLargest);
+        size_t cfd_size = cfd->mem()->ApproximateMemoryUsage();
+        if (cfd_picked == nullptr || cfd_size > largest_cfd_size) {
+          cfd_picked = cfd;
+          largest_cfd_size = cfd_size;
         }
       }
     }
-    if (cfd_picked != nullptr) {
-      cfds.push_back(cfd_picked);
-    }
   }
+  if (cfd_picked != nullptr) {
+    cfds.push_back(cfd_picked);
+  }
+  GenerateFlushRequest(&cfds, &flush_req_vec);
   if (flush_reason == FlushReason::kWriteBufferManager) {
     for (auto cfd : cfds) {
       ROCKS_LOG_BUFFER(
@@ -1231,15 +1198,8 @@ Status DBImpl::HandleWriteBufferFull(WriteContext* write_context) {
     }
   }
   if (status.ok()) {
-    if (immutable_db_options_.atomic_flush) {
-      AssignAtomicFlushSeq(cfds);
-    }
-    for (const auto cfd : cfds) {
-      cfd->imm()->FlushRequested();
-    }
-    FlushRequest flush_req;
-    GenerateFlushRequest(cfds, &flush_req);
-    SchedulePendingFlush(flush_req, flush_reason);
+    AssignAtomicFlushSeq(flush_req_vec);
+    SchedulePendingFlush(flush_req_vec, flush_reason);
     MaybeScheduleFlushOrCompaction();
   }
   return status;
@@ -1368,19 +1328,14 @@ Status DBImpl::ThrottleLowPriWritesIfNeeded(const WriteOptions& write_options,
 }
 
 Status DBImpl::ScheduleFlushes(WriteContext* context) {
+  mutex_.AssertHeld();
   autovector<ColumnFamilyData*> cfds;
-  if (immutable_db_options_.atomic_flush) {
-    SelectColumnFamiliesForAtomicFlush(&cfds);
-    for (auto cfd : cfds) {
-      cfd->Ref();
-    }
-    flush_scheduler_.Clear();
-  } else {
-    ColumnFamilyData* tmp_cfd;
-    while ((tmp_cfd = flush_scheduler_.TakeNextColumnFamily()) != nullptr) {
-      cfds.push_back(tmp_cfd);
-    }
+  FlushRequestVec flush_req_vec;
+  ColumnFamilyData* tmp_cfd;
+  while ((tmp_cfd = flush_scheduler_.TakeNextColumnFamily()) != nullptr) {
+    cfds.push_back(tmp_cfd);
   }
+  GenerateFlushRequest(&cfds, &flush_req_vec);
   Status status;
   for (auto& cfd : cfds) {
     if (!cfd->mem()->IsEmpty()) {
@@ -1395,12 +1350,8 @@ Status DBImpl::ScheduleFlushes(WriteContext* context) {
     }
   }
   if (status.ok()) {
-    if (immutable_db_options_.atomic_flush) {
-      AssignAtomicFlushSeq(cfds);
-    }
-    FlushRequest flush_req;
-    GenerateFlushRequest(cfds, &flush_req);
-    SchedulePendingFlush(flush_req, FlushReason::kWriteBufferFull);
+    AssignAtomicFlushSeq(flush_req_vec);
+    SchedulePendingFlush(flush_req_vec, FlushReason::kWriteBufferFull);
     MaybeScheduleFlushOrCompaction();
   }
   return status;

--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -1101,7 +1101,7 @@ Status DBImpl::SwitchWAL(WriteContext* write_context) {
     }
   }
   if (status.ok()) {
-    PrepareFlushReqVec(flush_req_vec);
+    PrepareFlushReqVec(flush_req_vec, true /* force_flush */);
     SchedulePendingFlush(flush_req_vec, FlushReason::kWriteBufferManager);
     MaybeScheduleFlushOrCompaction();
   }
@@ -1198,7 +1198,7 @@ Status DBImpl::HandleWriteBufferFull(WriteContext* write_context) {
     }
   }
   if (status.ok()) {
-    PrepareFlushReqVec(flush_req_vec);
+    PrepareFlushReqVec(flush_req_vec, true /* force_flush */);
     SchedulePendingFlush(flush_req_vec, flush_reason);
     MaybeScheduleFlushOrCompaction();
   }
@@ -1353,7 +1353,7 @@ Status DBImpl::ScheduleFlushes(WriteContext* context) {
     }
   }
   if (status.ok()) {
-    PrepareFlushReqVec(flush_req_vec);
+    PrepareFlushReqVec(flush_req_vec, false /* force_flush */);
     SchedulePendingFlush(flush_req_vec, FlushReason::kWriteBufferFull);
     MaybeScheduleFlushOrCompaction();
   }

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -292,8 +292,11 @@ Status FlushJob::Run(LogsWithPrepTracker* prep_tracker) {
   return s;
 }
 
-void FlushJob::Cancel() {
+void FlushJob::Cancel(const Status& s) {
   db_mutex_->AssertHeld();
+  for (auto mem : mems_) {
+    mem->GetEdits()->DoApplyCallback(s);
+  }
   assert(base_ != nullptr);
   base_->Unref();
 }

--- a/db/flush_job.h
+++ b/db/flush_job.h
@@ -77,7 +77,7 @@ class FlushJob {
   // Once PickMemTable() is called, either Run() or Cancel() has to be called.
   void PickMemTable();
   Status Run(LogsWithPrepTracker* prep_tracker = nullptr);
-  void Cancel();
+  void Cancel(const Status& s);
   const std::vector<FileMetaData>& GetFileMetas() const { return meta_; }
   const std::vector<TableProperties>& GetTableProperties() const {
     return table_properties_;

--- a/db/version_builder_test.cc
+++ b/db/version_builder_test.cc
@@ -490,6 +490,8 @@ TEST_F(VersionBuilderTest, HugeLSM) {
   version_builder.Apply(&version_edit);
 
   version_builder.SaveTo(&new_vstorage);
+
+  UnrefFilesInVersion(&new_vstorage);
 }
 
 }  // namespace TERARKDB_NAMESPACE

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -377,6 +377,7 @@ class VersionEdit {
     for (auto& apply_callback : apply_callback_vec_) {
       apply_callback(s);
     }
+    apply_callback_vec_.clear();
   }
 
   void MarkAtomicGroup(uint32_t remaining_entries) {

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3471,6 +3471,9 @@ Status VersionSet::LogAndApply(
     // TODO (yanqin) maybe use a different status code to denote column family
     // drop other than OK and ShutdownInProgress
     for (int i = 0; i != num_cfds; ++i) {
+      for (auto& edit : manifest_writers_.front()->edit_list) {
+        edit->DoApplyCallback(Status::ShutdownInProgress());
+      }
       manifest_writers_.pop_front();
     }
     // Notify new head of manifest write queue.

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -159,6 +159,11 @@ enum UpdateStatus {     // Return status For inplace update callback
   UPDATED = 2,          // No inplace update. Merged value set
 };
 
+class AtomicFlushGroup {
+ public:
+  virtual ~AtomicFlushGroup(){};
+};
+
 struct AdvancedColumnFamilyOptions {
   // The maximum number of write buffers that are built up in memory.
   // The default and the minimum number is 2, so that when 1 write buffer
@@ -558,6 +563,8 @@ struct AdvancedColumnFamilyOptions {
   std::shared_ptr<MemTableRepFactory> memtable_factory =
       std::shared_ptr<SkipListFactory>(new SkipListFactory);
 
+  std::shared_ptr<AtomicFlushGroup> atomic_flush_group;
+
   // Block-based table related options are moved to BlockBasedTableOptions.
   // Related options that were originally here but now moved include:
   //   no_block_cache
@@ -663,5 +670,7 @@ struct AdvancedColumnFamilyOptions {
   // Does not have any effect.
   bool purge_redundant_kvs_while_flush = true;
 };
+
+extern std::shared_ptr<AtomicFlushGroup> NewAtomicFlushGroup();
 
 }  // namespace TERARKDB_NAMESPACE

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -563,6 +563,21 @@ struct AdvancedColumnFamilyOptions {
   std::shared_ptr<MemTableRepFactory> memtable_factory =
       std::shared_ptr<SkipListFactory>(new SkipListFactory);
 
+  // If set, RocksDB supports flushing multiple column families and committin
+  // their results atomically to MANIFEST.
+  //
+  // Note that it is not necessary to set atomic_flush_group if WAL is always
+  // enabled since WAL allows the database to be restored to the last persistent
+  // state in WAL.
+  //
+  // This option is useful when there are column families with writes NOT
+  // protected by WAL.
+  //
+  // For both manual flush and auto-triggered flush, RocksDB atomically flushes
+  // ALL column families which in same group.
+  //
+  // Currently, any WAL-enabled writes after atomic flush may be replayed
+  // independently if the process crashes later and tries to recover.
   std::shared_ptr<AtomicFlushGroup> atomic_flush_group;
 
   // Block-based table related options are moved to BlockBasedTableOptions.

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1071,20 +1071,6 @@ struct DBOptions {
   // file.
   bool manual_wal_flush = false;
 
-  // If true, RocksDB supports flushing multiple column families and committing
-  // their results atomically to MANIFEST. Note that it is not
-  // necessary to set atomic_flush to true if WAL is always enabled since WAL
-  // allows the database to be restored to the last persistent state in WAL.
-  // This option is useful when there are column families with writes NOT
-  // protected by WAL.
-  // For manual flush, application has to specify which column families to
-  // flush atomically in DB::Flush.
-  // For auto-triggered flush, RocksDB atomically flushes ALL column families.
-  //
-  // Currently, any WAL-enabled writes after atomic flush may be replayed
-  // independently if the process crashes later and tries to recover.
-  bool atomic_flush = false;
-
   // If true, working thread may avoid doing unnecessary and long-latency
   // operation (such as deleting obsolete files directly or deleting memtable)
   // and will instead schedule a background job to do it.

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -56,6 +56,7 @@ ImmutableCFOptions::ImmutableCFOptions(const ImmutableDBOptions& db_options,
       allow_mmap_writes(db_options.allow_mmap_writes),
       db_paths(db_options.db_paths),
       memtable_factory(cf_options.memtable_factory.get()),
+      atomic_flush_group(cf_options.atomic_flush_group.get()),
       table_factory(cf_options.table_factory.get()),
       table_properties_collector_factories(
           cf_options.table_properties_collector_factories),

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -82,6 +82,8 @@ struct ImmutableCFOptions {
 
   MemTableRepFactory* memtable_factory;
 
+  AtomicFlushGroup* atomic_flush_group;
+
   TableFactory* table_factory;
 
   Options::TablePropertiesCollectorFactories

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -92,7 +92,6 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       preserve_deletes(options.preserve_deletes),
       two_write_queues(options.two_write_queues),
       manual_wal_flush(options.manual_wal_flush),
-      atomic_flush(options.atomic_flush),
       avoid_unnecessary_blocking_io(options.avoid_unnecessary_blocking_io),
       persist_stats_to_disk(options.persist_stats_to_disk) {
 }
@@ -244,8 +243,6 @@ void ImmutableDBOptions::Dump(Logger* log) const {
                    two_write_queues);
   ROCKS_LOG_HEADER(log, "                       Options.manual_wal_flush: %d",
                    manual_wal_flush);
-  ROCKS_LOG_HEADER(log, "                           Options.atomic_flush: %d",
-                   atomic_flush);
   ROCKS_LOG_HEADER(log, "          Options.avoid_unnecessary_blocking_io: %d",
                    avoid_unnecessary_blocking_io);
   ROCKS_LOG_HEADER(log, "                Options.persist_stats_to_disk: %u",

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -85,7 +85,6 @@ struct ImmutableDBOptions {
   bool preserve_deletes;
   bool two_write_queues;
   bool manual_wal_flush;
-  bool atomic_flush;
   bool avoid_unnecessary_blocking_io;
   bool persist_stats_to_disk;
 };

--- a/options/options.cc
+++ b/options/options.cc
@@ -36,6 +36,15 @@
 
 namespace TERARKDB_NAMESPACE {
 
+class AtomicFlushGroupImpl : public AtomicFlushGroup {
+ public:
+  AtomicFlushGroupImpl() {}
+};
+
+std::shared_ptr<AtomicFlushGroup> NewAtomicFlushGroup() {
+  return std::shared_ptr<AtomicFlushGroup>(new AtomicFlushGroupImpl());
+}
+
 AdvancedColumnFamilyOptions::AdvancedColumnFamilyOptions() {
   assert(memtable_factory.get() != nullptr);
 }
@@ -134,6 +143,8 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
       compaction_dispatcher ? compaction_dispatcher->Name() : "None");
   ROCKS_LOG_HEADER(log, "        Options.memtable_factory: %s",
                    memtable_factory->Name());
+  ROCKS_LOG_HEADER(log, "      Options.atomic_flush_group: %012X",
+                   atomic_flush_group.get());
   ROCKS_LOG_HEADER(log, "           Options.table_factory: %s",
                    table_factory->Name());
   ROCKS_LOG_HEADER(log, "           table_factory options: %s",

--- a/options/options.cc
+++ b/options/options.cc
@@ -38,7 +38,13 @@ namespace TERARKDB_NAMESPACE {
 
 class AtomicFlushGroupImpl : public AtomicFlushGroup {
  public:
-  AtomicFlushGroupImpl() {}
+  AtomicFlushGroupImpl() {
+    static std::atomic_size_t group_id_seed{0};
+    group_id = ++group_id_seed;
+  }
+
+ private:
+  size_t group_id;  //  diagnosis only
 };
 
 std::shared_ptr<AtomicFlushGroup> NewAtomicFlushGroup() {

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -140,7 +140,6 @@ DBOptions BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
   options.preserve_deletes = immutable_db_options.preserve_deletes;
   options.two_write_queues = immutable_db_options.two_write_queues;
   options.manual_wal_flush = immutable_db_options.manual_wal_flush;
-  options.atomic_flush = immutable_db_options.atomic_flush;
   options.avoid_unnecessary_blocking_io =
       immutable_db_options.avoid_unnecessary_blocking_io;
 
@@ -1776,10 +1775,6 @@ std::unordered_map<std::string, OptionTypeInfo>
         {"seq_per_batch",
          {0, OptionType::kBoolean, OptionVerificationType::kDeprecated, false,
           0}},
-        {"atomic_flush",
-         {offsetof(struct DBOptions, atomic_flush), OptionType::kBoolean,
-          OptionVerificationType::kNormal, false,
-          offsetof(struct ImmutableDBOptions, atomic_flush)}},
         {"avoid_unnecessary_blocking_io",
          {offsetof(struct DBOptions, avoid_unnecessary_blocking_io),
           OptionType::kBoolean, OptionVerificationType::kNormal, false,

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -305,7 +305,6 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
                              "two_write_queues=false;"
                              "manual_wal_flush=false;"
                              "seq_per_batch=false;"
-                             "atomic_flush=false;"
                              "avoid_unnecessary_blocking_io=false",
                              new_options));
 
@@ -350,6 +349,8 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
        sizeof(std::vector<int>)},
       {offset_of(&ColumnFamilyOptions::memtable_factory),
        sizeof(std::shared_ptr<MemTableRepFactory>)},
+      {offset_of(&ColumnFamilyOptions::atomic_flush_group),
+       sizeof(std::shared_ptr<AtomicFlushGroup>)},
       {offset_of(&ColumnFamilyOptions::table_properties_collector_factories),
        sizeof(ColumnFamilyOptions::TablePropertiesCollectorFactories)},
       {offset_of(&ColumnFamilyOptions::comparator), sizeof(Comparator*)},

--- a/table/block_based_table_row_ttl_test.cc
+++ b/table/block_based_table_row_ttl_test.cc
@@ -142,6 +142,7 @@ TEST_F(BlockBasedTableBuilderTest, FunctionTest) {
               props->user_collected_properties.end());
   // ASSERT_EQ(std::numeric_limits<uint64_t>::max(),
   // props->scan_gap_expire_time);
+  options.info_log.reset();
   delete options.env;
 }
 
@@ -269,6 +270,7 @@ TEST_P(BlockBasedTableBuilderTest, BoundaryTest) {
              [](const int& val) -> void { std::cout << val << "-"; });
     std::cout << std::endl;
   }
+  options.info_log.reset();
   delete options.env;
 }
 }  // namespace TERARKDB_NAMESPACE

--- a/table/terark_zip_table_row_ttl_test.cc
+++ b/table/terark_zip_table_row_ttl_test.cc
@@ -141,6 +141,7 @@ TEST_F(TerarkZipTableBuilderTest, FunctionTest) {
               props->user_collected_properties.end());
   // ASSERT_EQ(std::numeric_limits<uint64_t>::max(),
   // props->scan_gap_expire_time);
+  options.info_log.reset();
   delete options.env;
 }
 
@@ -268,6 +269,7 @@ TEST_P(TerarkZipTableBuilderTest, BoundaryTest) {
              [](const int& val) -> void { std::cout << val << "-"; });
     std::cout << std::endl;
   }
+  options.info_log.reset();
   delete options.env;
 }
 }  // namespace TERARKDB_NAMESPACE

--- a/terark-tools/terark-test/chaos_test.cc
+++ b/terark-tools/terark-test/chaos_test.cc
@@ -62,7 +62,6 @@ class ChaosTest {
   }
 
   void set_options() {
-    options.atomic_flush = false;
     options.allow_mmap_reads = false;
     options.max_open_files = 8192;
     options.allow_fallocate = true;

--- a/terark-tools/terark-test/stress_test.cpp
+++ b/terark-tools/terark-test/stress_test.cpp
@@ -308,7 +308,6 @@ std::string get_value(size_t i) {
 void get_options(int argc, const char *argv[], TERARKDB_NAMESPACE::Options &options,
                  TERARKDB_NAMESPACE::BlockBasedTableOptions &bbto,
                  TERARKDB_NAMESPACE::TerarkZipTableOptions &tzto) {
-  options.atomic_flush = false;
   options.allow_mmap_reads = true;
   options.max_open_files = 8192;
   options.allow_fallocate = true;

--- a/tools/db_stress.cc
+++ b/tools/db_stress.cc
@@ -2448,7 +2448,9 @@ class StressTest {
           FLAGS_universal_max_merge_width;
       options_.compaction_options_universal.max_size_amplification_percent =
           FLAGS_universal_max_size_amplification_percent;
-      options_.atomic_flush = FLAGS_atomic_flush;
+      if (FLAGS_atomic_flush) {
+        options_.atomic_flush_group = NewAtomicFlushGroup();
+      }
     } else {
 #ifdef ROCKSDB_LITE
       fprintf(stderr, "--options_file not supported in lite mode\n");


### PR DESCRIPTION
Related Issue:https://github.com/facebook/rocksdb/pull/4023
1. We want to disable partial data's WAL instead of disabling all data's WAL, in order to keep the consistency of data without WAL, so we need to use atomic_flush. 
2. Atomic_flush will flush all column families that have unflushed data in the database, But we only need to keep the consistency of column families without WAL.
3. We add a column family option to enable column family group atomic flush, we implement origin atomic_flush when all column family in a common group.

 So we refactor the feature to support partial atomic_flush.