### PR TITLE
Reduce write stall caused by SwitchWAL

### DIFF
--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -1399,7 +1399,8 @@ TEST_F(DBWALTest, RestoreTotalLogSizeAfterRecoverWithoutFlush) {
             1 * kMB);
   // Write one more key to trigger flush.
   ASSERT_OK(Put(0, "foo", "v2"));
-  dbfull()->TEST_WaitForFlushMemTable();
+  dbfull()->TEST_WaitForFlushMemTable(handles_[0]);  // "default"
+  dbfull()->TEST_WaitForFlushMemTable(handles_[1]);  // "one"
   // Flushed two column families.
   ASSERT_EQ(2, test_listener->count.load());
 }

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -276,6 +276,19 @@ class MemTableList {
     return memlist.front()->GetID();
   }
 
+  SequenceNumber GetEarliestCreationSeqNotFlushInProgress() const {
+    auto& memlist = current_->memlist_;
+    // Scan the memtable list from old to new
+    for (auto it = memlist.rbegin(); it != memlist.rend(); ++it) {
+      MemTable* mem = *it;
+      if (!mem->flush_in_progress_ &&
+          mem->atomic_flush_seqno_ == kMaxSequenceNumber) {
+        return mem->GetCreationSeq();
+      }
+    }
+    return kMaxSequenceNumber;
+  }
+
   void AssignAtomicFlushSeq(const SequenceNumber& seq) {
     const auto& memlist = current_->memlist_;
     // Scan the memtable list from new to old

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -206,7 +206,7 @@ void ImmutableDBOptions::Dump(Logger* log) const {
       log, "    Options.sst_file_manager.rate_bytes_per_sec: %" PRIi64,
       sst_file_manager ? sst_file_manager->GetDeleteRateBytesPerSecond() : 0);
   ROCKS_LOG_HEADER(log, "                      Options.wal_recovery_mode: %d",
-                   wal_recovery_mode);
+                   int(wal_recovery_mode));
   ROCKS_LOG_HEADER(log, "                 Options.enable_thread_tracking: %d",
                    enable_thread_tracking);
   ROCKS_LOG_HEADER(log, "                 Options.enable_pipelined_write: %d",
@@ -222,9 +222,9 @@ void ImmutableDBOptions::Dump(Logger* log) const {
                    "           Options.write_thread_slow_yield_usec: %" PRIu64,
                    write_thread_slow_yield_usec);
   if (row_cache) {
-    ROCKS_LOG_HEADER(
-        log, "                              Options.row_cache: %" PRIu64,
-        row_cache->GetCapacity());
+    ROCKS_LOG_HEADER(log,
+                     "                              Options.row_cache: %zu",
+                     row_cache->GetCapacity());
   } else {
     ROCKS_LOG_HEADER(log,
                      "                              Options.row_cache: None");
@@ -320,7 +320,7 @@ void MutableDBOptions::Dump(Logger* log) const {
                    stats_dump_period_sec);
   ROCKS_LOG_HEADER(log, "               Options.stats_persist_period_sec: %d",
                    stats_persist_period_sec);
-  ROCKS_LOG_HEADER(log, "              Options.stats_history_buffer_size: %d",
+  ROCKS_LOG_HEADER(log, "              Options.stats_history_buffer_size: %zu",
                    stats_history_buffer_size);
   ROCKS_LOG_HEADER(log, "                         Options.max_open_files: %d",
                    max_open_files);

--- a/options/options.cc
+++ b/options/options.cc
@@ -149,8 +149,8 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
       compaction_dispatcher ? compaction_dispatcher->Name() : "None");
   ROCKS_LOG_HEADER(log, "        Options.memtable_factory: %s",
                    memtable_factory->Name());
-  ROCKS_LOG_HEADER(log, "      Options.atomic_flush_group: %012X",
-                   atomic_flush_group.get());
+  ROCKS_LOG_HEADER(log, "      Options.atomic_flush_group: %012" PRIXPTR,
+                   uintptr_t(atomic_flush_group.get()));
   ROCKS_LOG_HEADER(log, "           Options.table_factory: %s",
                    table_factory->Name());
   ROCKS_LOG_HEADER(log, "           table_factory options: %s",
@@ -197,17 +197,13 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
       log, "              Options.bottommost_compression_opts.strategy: %d",
       bottommost_compression_opts.strategy);
   ROCKS_LOG_HEADER(
-      log,
-      "        Options.bottommost_compression_opts.max_dict_bytes: "
-      "%" ROCKSDB_PRIszt,
+      log, "        Options.bottommost_compression_opts.max_dict_bytes: %u",
       bottommost_compression_opts.max_dict_bytes);
   ROCKS_LOG_HEADER(
-      log,
-      "  Options.bottommost_compression_opts.zstd_max_train_bytes: "
-      "%" ROCKSDB_PRIszt,
+      log, "  Options.bottommost_compression_opts.zstd_max_train_bytes: %u",
       bottommost_compression_opts.zstd_max_train_bytes);
   ROCKS_LOG_HEADER(
-      log, "                 Options.bottommost_compression_opts.enabled: %s",
+      log, "               Options.bottommost_compression_opts.enabled: %s",
       bottommost_compression_opts.enabled ? "true" : "false");
   ROCKS_LOG_HEADER(log, "           Options.compression_opts.window_bits: %d",
                    compression_opts.window_bits);
@@ -215,12 +211,10 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
                    compression_opts.level);
   ROCKS_LOG_HEADER(log, "              Options.compression_opts.strategy: %d",
                    compression_opts.strategy);
-  ROCKS_LOG_HEADER(
-      log, "        Options.compression_opts.max_dict_bytes: %" ROCKSDB_PRIszt,
-      compression_opts.max_dict_bytes);
-  ROCKS_LOG_HEADER(
-      log, "  Options.compression_opts.zstd_max_train_bytes: %" ROCKSDB_PRIszt,
-      compression_opts.zstd_max_train_bytes);
+  ROCKS_LOG_HEADER(log, "        Options.compression_opts.max_dict_bytes: %u",
+                   compression_opts.max_dict_bytes);
+  ROCKS_LOG_HEADER(log, "  Options.compression_opts.zstd_max_train_bytes: %u",
+                   compression_opts.zstd_max_train_bytes);
   ROCKS_LOG_HEADER(log, "               Options.compression_opts.enabled: %s",
                    compression_opts.enabled ? "true" : "false");
   ROCKS_LOG_HEADER(log, "     Options.level0_file_num_compaction_trigger: %d",

--- a/table/plain_table_index.cc
+++ b/table/plain_table_index.cc
@@ -206,8 +206,8 @@ Slice PlainTableIndexBuilder::FillIndexes(
   assert(sub_index_offset == sub_index_size_);
 
   ROCKS_LOG_DEBUG(ioptions_.info_log,
-                  "hash table size: %d, suffix_map length %" ROCKSDB_PRIszt,
-                  index_size_, sub_index_size_);
+                  "hash table size: %u, suffix_map length %u", index_size_,
+                  sub_index_size_);
   return Slice(allocated, GetTotalSize());
 }
 

--- a/table/terark_zip_table.cc
+++ b/table/terark_zip_table.cc
@@ -373,7 +373,7 @@ TableBuilder* TerarkZipTableFactory::NewTableBuilder(
       if (keyPrefixLen != table_options_.keyPrefixLen) {
         WARN(table_builder_options.ioptions.info_log,
              "TerarkZipTableFactory::NewTableBuilder() found non best config , "
-             "keyPrefixLen = %zd , prefix_extractor = %zd\n",
+             "keyPrefixLen = %u , prefix_extractor = %u\n",
              table_options_.keyPrefixLen, keyPrefixLen);
       }
       keyPrefixLen =

--- a/util/threadpool_imp.cc
+++ b/util/threadpool_imp.cc
@@ -278,6 +278,9 @@ void* ThreadPoolImpl::Impl::BGThreadWrapper(void* arg) {
     case Env::Priority::LOW:
       thread_type = ThreadStatus::LOW_PRIORITY;
       break;
+    case Env::Priority::USER:
+      thread_type = ThreadStatus::USER;
+      break;
     case Env::Priority::BOTTOM:
       thread_type = ThreadStatus::BOTTOM_PRIORITY;
       break;

--- a/utilities/flink/flink_compaction_filter.cc
+++ b/utilities/flink/flink_compaction_filter.cc
@@ -156,7 +156,7 @@ CompactionFilter::Decision FlinkCompactionFilter::FilterV2(
                                     config_cached_->timestamp_offset_,
                                     current_timestamp_, logger_);
   }
-  Debug(logger_.get(), "Decision: %d", decision);
+  Debug(logger_.get(), "Decision: %d", int(decision));
   return decision;
 }
 


### PR DESCRIPTION
In SwitchWAL, relative column families will do switch memtable that will increase an immutable, total number of immutable reaches to the threshold of write stall.
Especially, if the relative column family already has a flush job in the queue,  it is easier to reaches the threshold.
In this case, we ignore this switchWAL. We just need to wait for the flush job in the previous queue to complete, the WAL will be purge automatically.
<issue> close  https://github.com/bytedance/terarkdb/issues/123