### PR TITLE
support resort write batch

### DIFF
--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -462,13 +462,9 @@ size_t WriteThread::EnterAsBatchGroupLeader(Writer* leader,
       continue;
     }
 
-    if (!w->disable_wal && leader->disable_wal) {
+    if (!w->disable_wal != leader->disable_wal) {
       // Do not include a write that needs WAL into a batch that has
       // WAL disabled.
-      w = move_writer(w, newest_writer);
-      continue;
-    }
-    if (w->disable_wal && !leader->disable_wal) {
       w = move_writer(w, newest_writer);
       continue;
     }

--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -465,6 +465,8 @@ size_t WriteThread::EnterAsBatchGroupLeader(Writer* leader,
     if (!w->disable_wal != leader->disable_wal) {
       // Do not include a write that needs WAL into a batch that has
       // WAL disabled.
+      // Do not include a write that WAL disabled into a batch that has
+      // need WAL.
       w = move_writer(w, newest_writer);
       continue;
     }


### PR DESCRIPTION
1. we change the behavior of the write batch group commit. if a write batch leader did not disable WAL, the leader just can group commit followers who do not disable WAL.
2. resort writes batch, make leader can group commit followers as much as possible, reduce IOPS overhead.

<issue> close https://github.com/bytedance/terarkdb/issues/126