### PR TITLE
metrics: disaggregate metrics lib from terarkdb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ else()
   SET(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_PREFIX}/include)
 endif()
 
+# Enable or disable flags
 option(WITH_COVERAGE "build with gcov support" OFF)
 option(WITH_JEMALLOC "build with JeMalloc" ON)
 option(WITH_SNAPPY "build with SNAPPY" ON)
@@ -45,6 +46,13 @@ option(WITH_ZENFS "build with experimental zenfs" OFF)
 option(WITH_DIAGNOSE_CACHE "build with diagnosable cache support" OFF)
 option(WITH_BOOSTLIB "build with boost, if WITH_TERARK_ZIP is ON, this will also set to ON" OFF)
 option(WITH_TERARKDB_NAMESPACE "namespace" "terarkdb")
+
+# Plugins
+SET(BYTEDANCE_METRICS_PATH "" CACHE STRING "root directory of the metrics library source code")
+
+if(WITH_BYTEDANCE_METRICS AND BYTEDANCE_METRICS_PATH STREQUAL "" AND NOT TARGET metrics2)
+  MESSAGE(FATAL_ERROR "WITH_BYTEDANCE_METRICS enabled but BYTEDANCE_METRICS_PATH is not configured")
+endif()
 
 if(NOT WITH_TERARKDB_NAMESPACE)
   SET(WITH_TERARKDB_NAMESPACE "terarkdb")
@@ -96,6 +104,7 @@ MESSAGE("[terarkdb] WITH_JEMALLOC = ${WITH_JEMALLOC}, WITH_COVERAGE=${WITH_COVER
 MESSAGE("[terarkdb] CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}, BUILD_SUFFIX=${BUILD_SUFFIX}")
 MESSAGE("[terarkdb] CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
 MESSAGE("[terarkdb] CMAKE_THREAD_LIBS_INIT=${CMAKE_THREAD_LIBS_INIT}")
+MESSAGE("[terarkdb] BYTEDANCE_METRICS_PATH=${BYTEDANCE_METRICS_PATH}")
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/rocksdb/terark_namespace.h.in ${CMAKE_CURRENT_SOURCE_DIR}/include/rocksdb/terark_namespace.h)
 

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -43,14 +43,15 @@ IF(WITH_SNAPPY)
 ENDIF()
 
 # Bytedance Internal Metrics Library
-IF(WITH_BYTEDANCE_METRICS)	
+# You can either add metrics2 target or specify a BYTEDANCE_METRICS_PATH
+IF(WITH_BYTEDANCE_METRICS)
   IF(TARGET metrics2)
     MESSAGE("[terarkdb/third-party] bytedance_metrics2 target exist, re-use it!")
   ELSE()
     MESSAGE("[terarkdb/third-party] bytedance_metrics2 target not exist, let's build it!")
     ExternalProject_Add(metrics2-project
-        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/metrics2-cmake
-        CONFIGURE_COMMAND cmake ${CMAKE_CURRENT_SOURCE_DIR}/metrics2-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fPIC -DCMAKE_CXX_FLAGS=-fPIC -DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE}
+        SOURCE_DIR ${BYTEDANCE_METRICS_PATH}
+        CONFIGURE_COMMAND cmake ${BYTEDANCE_METRICS_PATH} -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-fPIC -DCMAKE_CXX_FLAGS=-fPIC -DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE}
         BUILD_IN_SOURCE 0
         BUILD_COMMAND $(MAKE)
         # metrics2 doesn't have a install instruction, so we have to manully install it
@@ -60,7 +61,7 @@ IF(WITH_BYTEDANCE_METRICS)
     ADD_DEPENDENCIES(metrics2 metrics2-project)
     SET_TARGET_PROPERTIES(metrics2 PROPERTIES
         IMPORTED_LOCATION ${CMAKE_BINARY_DIR}/lib/libmetrics2.a
-        INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/metrics2-cmake
+        INCLUDE_DIRECTORIES ${BYTEDANCE_METRICS_PATH}
         POSITION_INDEPENDENT_CODE ON
     )
   ENDIF()	

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -5870,7 +5870,8 @@ int db_bench_tool(int argc, char** argv) {
       metrics_reporter_factory = std::make_shared<ByteDanceMetricsReporterFactory>();
     }
 
-    Status s = NewZenfsEnv(&FLAGS_env, FLAGS_zbd_path, "db_bench", metrics_reporter_factory);
+    auto dbname = "dbname=" + FLAGS_zbd_path;
+    Status s = NewZenfsEnv(&FLAGS_env, FLAGS_zbd_path, dbname, metrics_reporter_factory);
     if (!s.ok()) {
         fprintf(stderr, "Error: Init zenfs env failed.\nStatus : %s\n", s.ToString().c_str());
         exit(1);


### PR DESCRIPTION
We had to add a new submodule each time we sync `github/bytedance/terarkdb` to bytedance internal terarkdb, so I removed this submodule and let the higher-level application handle the dependency themself

