### PR TITLE
env: add a new Frozen file API to WritableFile & FileWriter

### DIFF
--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -738,7 +738,6 @@ class DBImpl : public DB {
   }
 
   void AddToLogsToFreeQueue(log::Writer* log_writer) {
-    log_writer->file()->Close();
     logs_to_free_queue_.push_back(log_writer);
   }
 

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -738,7 +738,7 @@ class DBImpl : public DB {
   }
 
   void AddToLogsToFreeQueue(log::Writer* log_writer) {
-    log_writer->Close();
+    log_writer->file()->Close();
     logs_to_free_queue_.push_back(log_writer);
   }
 

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -1074,8 +1074,7 @@ Status DBImpl::RestoreAliveLogFiles(
   log_empty_ = false;
   for (size_t log_it = 0; log_it < log_numbers.size(); ++log_it) {
     uint64_t log_number = log_numbers[log_it];
-    uint64_t log_seq = log_seqs[log_it];
-    LogFileNumberSize log(log_number, log_seq);
+    LogFileNumberSize log(log_number, log_seqs[log_it]);
     std::string fname = LogFileName(immutable_db_options_.wal_dir, log_number);
     // This gets the appear size of the logs, not including preallocated space.
     s = env_->GetFileSize(fname, &log.size);
@@ -1419,8 +1418,8 @@ Status DBImpl::Open(const DBOptions& db_options, const std::string& dbname,
       if (impl->two_write_queues_) {
         impl->log_write_mutex_.Lock();
       }
-      impl->alive_log_files_.push_back(DBImpl::LogFileNumberSize(
-          impl->logfile_number_, impl->versions_->LastSequence()));
+      impl->alive_log_files_.emplace_back(impl->logfile_number_,
+                                          impl->versions_->LastSequence());
       if (impl->two_write_queues_) {
         impl->log_write_mutex_.Unlock();
       }

--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -1664,9 +1664,12 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context) {
                          cfd->GetName().c_str(),
                          cur_log_writer->get_log_number(), new_log_number);
       }
-      // Dirty trick for limited active zones.
-      // TODO(Changlong Chen) Revert it when using lavafs.
-      cur_log_writer->Close();
+      // We frozen a file to let low-level filesystem knows we don't need to write
+      // to this file anymore.
+      // For ext4 with page cache, this function call will do nothing and take no
+      // effect to the page cache thus RocksDB still be able to sync & close this
+      // file again.
+      cur_log_writer->Frozen();
       size_t alive_log_file_count = 0;
       // Output alive logger number for debug.
       for (auto& l : logs_) {

--- a/db/log_writer.cc
+++ b/db/log_writer.cc
@@ -33,12 +33,15 @@ Writer::Writer(std::unique_ptr<WritableFileWriter>&& dest, uint64_t log_number,
   }
 }
 
-Writer::~Writer() { Close(); }
+Writer::~Writer() {
+  WriteBuffer();
+  dest_->Close();
+}
 
-void Writer::Close() {
+void Writer::Frozen() {
   if (dest_) {
     dest_->Flush();
-    dest_->Close();
+    dest_->Frozen();
   }
 }
 

--- a/db/log_writer.cc
+++ b/db/log_writer.cc
@@ -35,17 +35,12 @@ Writer::Writer(std::unique_ptr<WritableFileWriter>&& dest, uint64_t log_number,
 
 Writer::~Writer() {
   WriteBuffer();
-  dest_->Close();
-}
-
-void Writer::Frozen() {
-  if (dest_) {
-    dest_->Flush();
-    dest_->Frozen();
-  }
+  Frozen();
 }
 
 Status Writer::WriteBuffer() { return dest_->Flush(); }
+
+Status Writer::Frozen() { return dest_->Frozen(); }
 
 Status Writer::AddRecord(const Slice& slice) {
   const char* ptr = slice.data();

--- a/db/log_writer.h
+++ b/db/log_writer.h
@@ -83,7 +83,10 @@ class Writer {
   WritableFileWriter* file() { return dest_.get(); }
   const WritableFileWriter* file() const { return dest_.get(); }
 
-  void Close();
+  // Notify underlaying filesystem that this file wil not be written again.
+  // We didn't close it yet becasue some filesystem may uses page cache and thus
+  // may still have data un-synced if we close it immedately.
+  void Frozen();
 
   uint64_t get_log_number() const { return log_number_; }
 

--- a/db/log_writer.h
+++ b/db/log_writer.h
@@ -83,14 +83,14 @@ class Writer {
   WritableFileWriter* file() { return dest_.get(); }
   const WritableFileWriter* file() const { return dest_.get(); }
 
-  // Notify underlaying filesystem that this file wil not be written again.
-  // We didn't close it yet becasue some filesystem may uses page cache and thus
-  // may still have data un-synced if we close it immedately.
-  void Frozen();
-
   uint64_t get_log_number() const { return log_number_; }
 
   Status WriteBuffer();
+
+  // Notify underlaying filesystem that this file wil not be written again.
+  // We didn't close it yet becasue some filesystem may uses page cache and thus
+  // may still have data un-synced if we close it immedately.
+  Status Frozen();
 
   bool TEST_BufferIsEmpty();
 

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -818,8 +818,8 @@ class WritableFile {
   // size due to whole pages writes. The behavior is undefined if called
   // with other writes to follow.
   virtual Status Truncate(uint64_t /*size*/) { return Status::OK(); }
+  virtual Status Frozen() { return Status::OK(); }
   virtual Status Close() = 0;
-  virtual Status Frozen() { return Status::OK();}
   virtual Status Flush() = 0;
   virtual Status Sync() = 0;  // sync data
 

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -819,6 +819,7 @@ class WritableFile {
   // with other writes to follow.
   virtual Status Truncate(uint64_t /*size*/) { return Status::OK(); }
   virtual Status Close() = 0;
+  virtual Status Frozen() { return Status::OK();}
   virtual Status Flush() = 0;
   virtual Status Sync() = 0;  // sync data
 
@@ -1532,6 +1533,7 @@ class WritableFileWrapper : public WritableFile {
     return target_->PositionedAppend(data, offset);
   }
   Status Truncate(uint64_t size) override { return target_->Truncate(size); }
+  Status Frozen() override { return target_->Frozen(); }
   Status Close() override { return target_->Close(); }
   Status Flush() override { return target_->Flush(); }
   Status Sync() override { return target_->Sync(); }

--- a/util/file_reader_writer.cc
+++ b/util/file_reader_writer.cc
@@ -353,18 +353,11 @@ Status WritableFileWriter::Close() {
   return s;
 }
 
-Status WritableFileWriter::Frozen() {
-  auto s = writable_file_->Frozen();
-  return s;
-}
+Status WritableFileWriter::Frozen() { return writable_file_->Frozen(); }
 
 // write out the cached data to the OS cache or storage if direct I/O
 // enabled
 Status WritableFileWriter::Flush() {
-  if (!writable_file_) {
-    return Status::OK();
-  }
-
   Status s;
   TEST_KILL_RANDOM("WritableFileWriter::Flush:0",
                    rocksdb_kill_odds * REDUCE_ODDS2);
@@ -392,9 +385,6 @@ Status WritableFileWriter::Flush() {
 }
 
 Status WritableFileWriter::Sync(bool use_fsync) {
-  if (!writable_file_) {
-    return Status::OK();
-  }
   Status s = Flush();
   if (!s.ok()) {
     return s;
@@ -412,9 +402,6 @@ Status WritableFileWriter::Sync(bool use_fsync) {
 }
 
 Status WritableFileWriter::SyncWithoutFlush(bool use_fsync) {
-  if (!writable_file_) {
-    return Status::OK();
-  }
   if (!writable_file_->IsSyncThreadSafe()) {
     return Status::NotSupported(
         "Can't WritableFileWriter::SyncWithoutFlush() because "

--- a/util/file_reader_writer.cc
+++ b/util/file_reader_writer.cc
@@ -353,6 +353,11 @@ Status WritableFileWriter::Close() {
   return s;
 }
 
+Status WritableFileWriter::Frozen() {
+  auto s = writable_file_->Frozen();
+  return s;
+}
+
 // write out the cached data to the OS cache or storage if direct I/O
 // enabled
 Status WritableFileWriter::Flush() {

--- a/util/file_reader_writer.h
+++ b/util/file_reader_writer.h
@@ -218,6 +218,12 @@ class WritableFileWriter {
 
   Status Close();
 
+  // Notify low-level filesystem that we will not write shi file again. But
+  // there may be some inflight data (e.g. some filesystem uses page cache).
+  // If target filesystem do not use a cache layer it can safely close the file
+  // in low-level implementation.
+  Status Frozen();
+
   Status Sync(bool use_fsync);
 
   // Sync only the data that was already Flush()ed. Safe to call concurrently

--- a/util/file_reader_writer.h
+++ b/util/file_reader_writer.h
@@ -216,13 +216,13 @@ class WritableFileWriter {
 
   Status Flush();
 
-  Status Close();
-
   // Notify low-level filesystem that we will not write shi file again. But
   // there may be some inflight data (e.g. some filesystem uses page cache).
   // If target filesystem do not use a cache layer it can safely close the file
   // in low-level implementation.
   Status Frozen();
+
+  Status Close();
 
   Status Sync(bool use_fsync);
 


### PR DESCRIPTION
RocksDB may sync data after a file was closed (page cache enabled).  But for ZenFS, it will release active zone resources and reject any further writes.

To address this problem we added a `Frozen` API that can notify ZenFS it doesn't need this file again, so ZenFS could safely close it, and since ZenFS doesn't have page cache so later data sync would take no effect.

For other filesystems(e.g. ext4) the logic is still reminded since Frozen() will do nothing on page cache enabled filesystems.


Signed-off-by: Kuankuan Guo <guokuankuan@bytedance.com>