### PR TITLE
add compile flag for switching to zenfs refactor version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1209,6 +1209,12 @@ if(WITH_TOOLS)
   target_link_libraries(db_bench${ARTIFACT_SUFFIX} gtest ${ROCKSDB_STATIC_LIB})
 
   if(WITH_ZENFS)
+    # WITH_ZENFS_REFACTOR is an experimental feature for async metazone rolloever
+    option(WITH_ZENFS_REFACTOR "build with zenfs refactor" OFF)
+    if(WITH_ZENFS_REFACTOR)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWITH_ZENFS_REFACTOR")
+    endif()
+
     include_directories(third-party/zenfs)
     add_executable(zenfs${ARTIFACT_SUFFIX} third-party/zenfs/util/zenfs.cc
             $<TARGET_OBJECTS:testharness>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1211,8 +1211,17 @@ if(WITH_TOOLS)
   if(WITH_ZENFS)
     include_directories(third-party/zenfs)
     add_executable(zenfs${ARTIFACT_SUFFIX} third-party/zenfs/util/zenfs.cc
-        $<TARGET_OBJECTS:testharness>)
+            $<TARGET_OBJECTS:testharness>)
     target_link_libraries(zenfs${ARTIFACT_SUFFIX} gtest ${ROCKSDB_STATIC_LIB})
+
+    FILE(GLOB ZENFS_TESTS third-party/zenfs/test/*_test.cc)
+    foreach(sourcefile ${ZENFS_TESTS})
+      get_filename_component(exename ${sourcefile} NAME_WE)
+      add_executable(${exename}${ARTIFACT_SUFFIX} ${sourcefile}
+              $<TARGET_OBJECTS:testharness>)
+      target_link_libraries(${exename}${ARTIFACT_SUFFIX} gtest ${ROCKSDB_STATIC_LIB})
+    endforeach(sourcefile ${BENCHMARKS})
+
   endif()
 
   if(WITH_TERARK_ZIP)


### PR DESCRIPTION
adding WITH_ZENFS_REFACTOR for refactoring async support for metadata rollover

Usage: https://github.com/bzbd/zenfs/pull/46