### PR TITLE
ci: remove cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Create Build Environment
       run: |
-        sudo apt-get update
-        sudo apt-get install -f libaio-dev
-        sudo apt-get install -f cmake
-        sudo apt-get install -f autoconf
+        sudo apt-get update -yy
+        sudo apt-get install -f libaio-dev cmake autoconf -yy
         git submodule update --init --recursive
 
     - name: Create Build Directory
@@ -37,4 +35,4 @@ jobs:
 
     - name: Build
       working-directory: build
-      run: make -j
+      run: make -j $(nproc)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,13 +28,6 @@ jobs:
         sudo apt-get install -f autoconf
         git submodule update --init --recursive
 
-    - uses: actions/cache@v2
-      name: Recover from cache
-      with:
-        path: |
-          build/
-        key: ${{ runner.os }}-cmake-${{ hashFiles('CMakeLists.txt') }}
-    
     - name: Create Build Directory
       run: cmake -E make_directory build || true
         


### PR DESCRIPTION
After we are using self-hosted runners, it takes only 2min to build TerarkDB, but 22min to upload the build cache to GitHub. A build cache is expected to accelerate the building process, but it seems that after we started using self-hosted runners, it slowed down the build. Therefore, I suggest removing the build cache.