### PR TITLE
chore: (partially) fix macOS build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,8 @@
 # WITH_TESTS=1 ./build.sh
 #
 
+set -e
+
 BASE=$PWD
 OUTPUT=output
 mkdir -p $OUTPUT
@@ -18,16 +20,19 @@ fi
 
 git submodule update --init --recursive
 
+# compatibility with macOS
+NPROC=$(nproc || sysctl -n hw.logicalcpu)
+
 if [ "$WITH_TESTS" == "1" ]; then
   WITH_TESTS=ON
   echo "build $BUILD_TYPE, with_tests = $WITH_TESTS"
   echo "You are building TerarkDB with tests, so debug mode is enabled"
-  cd $BASE/$OUTPUT && cmake ../ -DCMAKE_INSTALL_PREFIX=$OUTPUT -DCMAKE_BUILD_TYPE=Debug -DWITH_TESTS=${WITH_TESTS} -DWITH_TOOLS=ON -DWITH_TERARK_ZIP=ON
-  cd $BASE/$OUTPUT && make -j $(nproc) && make install
+  cd $BASE/$OUTPUT && cmake ../ -DCMAKE_INSTALL_PREFIX=$OUTPUT -DCMAKE_BUILD_TYPE=Debug -DWITH_TESTS=${WITH_TESTS} -DWITH_TOOLS=ON -DWITH_TERARK_ZIP=ON $@
+  cd $BASE/$OUTPUT && make -j $NPROC && make install
   echo "You are building TerarkDB with tests, so debug mode is enabled"
 else
   WITH_TESTS=OFF
   echo "build $BUILD_TYPE, with_tests = $WITH_TESTS"
-  cd $BASE/$OUTPUT && cmake ../ -DCMAKE_INSTALL_PREFIX=$OUTPUT -DCMAKE_BUILD_TYPE=Release -DWITH_TOOLS=ON -DWITH_TERARK_ZIP=ON
-  cd $BASE/$OUTPUT && make -j $(nproc) && make install
+  cd $BASE/$OUTPUT && cmake ../ -DCMAKE_INSTALL_PREFIX=$OUTPUT -DCMAKE_BUILD_TYPE=Release -DWITH_TOOLS=ON -DWITH_TERARK_ZIP=ON $@
+  cd $BASE/$OUTPUT && make -j $NPROC && make install
 fi

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -121,7 +121,7 @@ IF(WITH_ZSTD)
     MESSAGE("[terarkdb/third-party] zstd target not exist, let's build it!")
     ExternalProject_Add(zstd-project
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/zstd
-        CONFIGURE_COMMAND cp -rT ${CMAKE_CURRENT_SOURCE_DIR}/zstd .
+        CONFIGURE_COMMAND cp -r ${CMAKE_CURRENT_SOURCE_DIR}/zstd/ .
         BUILD_IN_SOURCE 0
         BUILD_COMMAND $(MAKE) "CXXFLAGS=-fPIC -O2" "CFLAGS=-fPIC -O2"
         INSTALL_COMMAND PREFIX=${CMAKE_BINARY_DIR} $(MAKE) install
@@ -144,7 +144,7 @@ IF(WITH_LZ4)
     MESSAGE("[terarkdb/third-party] lz4 target not exist, let's build it!")
     ExternalProject_Add(lz4-project
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/lz4
-        CONFIGURE_COMMAND cp -rT ${CMAKE_CURRENT_SOURCE_DIR}/lz4 .
+        CONFIGURE_COMMAND cp -r ${CMAKE_CURRENT_SOURCE_DIR}/lz4/ .
         BUILD_IN_SOURCE 0
         BUILD_COMMAND $(MAKE) "CXXFLAGS=-fPIC -O2" "CFLAGS=-fPIC -O2"
         INSTALL_COMMAND prefix=${CMAKE_BINARY_DIR} $(MAKE) install)
@@ -166,7 +166,7 @@ IF(WITH_BZ2)
     MESSAGE("[terarkdb/third-party] bzip2 target not exist, let's build it!")
     ExternalProject_Add(bzip2-project
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/bzip2
-        CONFIGURE_COMMAND cp -rT ${CMAKE_CURRENT_SOURCE_DIR}/bzip2 .
+        CONFIGURE_COMMAND cp -r ${CMAKE_CURRENT_SOURCE_DIR}/bzip2/ .
         BUILD_IN_SOURCE 0
         BUILD_COMMAND $(MAKE) "CXXFLAGS=-fPIC -O2" "CFLAGS=-fPIC -O2"
         INSTALL_COMMAND $(MAKE) install PREFIX=${CMAKE_BINARY_DIR})
@@ -188,7 +188,7 @@ IF(WITH_JEMALLOC)
     MESSAGE("[terarkdb/third-party] jemalloc target not exist, let's build it!")
     ExternalProject_Add(jemalloc-project
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/jemalloc
-        CONFIGURE_COMMAND cp -rT ${CMAKE_CURRENT_SOURCE_DIR}/jemalloc . && bash autogen.sh && "CFLAGS=-fPIC" "CXXFLAGS=-fPIC" "LDFLAGS=-fPIC" ./configure --prefix=${CMAKE_BINARY_DIR} --enable-prof
+        CONFIGURE_COMMAND cp -r ${CMAKE_CURRENT_SOURCE_DIR}/jemalloc/ . && bash autogen.sh && "CFLAGS=-fPIC" "CXXFLAGS=-fPIC" "LDFLAGS=-fPIC" ./configure --prefix=${CMAKE_BINARY_DIR} --enable-prof
         BUILD_IN_SOURCE 0
         BUILD_COMMAND $(MAKE)
         INSTALL_COMMAND $(MAKE) install PREFIX=${CMAKE_BINARY_DIR}


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

This PR only partially fixes compile error on macOS. For macOS users, they may need to run the `build.sh` as follows:

```
brew install gcc@9
export CC=gcc-9
export CXX=g++-9
./build.sh -DWITH_TERARK_ZIP=OFF
```

After that, `libterarkdb.a` can be successfully built, which means that users may use TerarkDB in other applications. But for other tools, there would be a linker error:

```
ld: warning: dylib (/usr/local/Cellar/gcc@9/9.4.0/lib/gcc/9/libstdc++.dylib) was built for newer macOS version (11.3) than being linked (11.0)
ld: warning: object file (../lib/libbz2.a(bzlib.o)) was built for newer macOS version (12.0) than being linked (11.0)
ld: warning: object file (../lib/libbz2.a(compress.o)) was built for newer macOS version (12.0) than being linked (11.0)
ld: warning: object file (../lib/libbz2.a(crctable.o)) was built for newer macOS version (12.0) than being linked (11.0)
ld: warning: object file (../lib/libbz2.a(decompress.o)) was built for newer macOS version (12.0) than being linked (11.0)
ld: warning: object file (../lib/libbz2.a(randtable.o)) was built for newer macOS version (12.0) than being linked (11.0)
ld: warning: object file (../lib/libbz2.a(blocksort.o)) was built for newer macOS version (12.0) than being linked (11.0)
ld: warning: object file (../lib/libbz2.a(huffman.o)) was built for newer macOS version (12.0) than being linked (11.0)
Undefined symbols for architecture x86_64:
  "_dallocx", referenced from:
      terarkdb::DumpMallocStats(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) in libterarkdb.a(malloc_stats.cc.o)
     (maybe you meant: _je_dallocx)
  "_mallctl", referenced from:
      terarkdb::DumpMallocStats(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) in libterarkdb.a(malloc_stats.cc.o)
     (maybe you meant: _je_mallctl, _je_mallctlnametomib , _je_mallctlbymib )
  "_mallctlbymib", referenced from:
      terarkdb::DumpMallocStats(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) in libterarkdb.a(malloc_stats.cc.o)
     (maybe you meant: _je_mallctlbymib)
  "_mallctlnametomib", referenced from:
      terarkdb::DumpMallocStats(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) in libterarkdb.a(malloc_stats.cc.o)
     (maybe you meant: _je_mallctlnametomib)
  "_malloc_stats_print", referenced from:
      terarkdb::DumpMallocStats(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) in libterarkdb.a(malloc_stats.cc.o)
     (maybe you meant: _je_malloc_stats_print)
  "_malloc_usable_size", referenced from:
      terarkdb::DumpMallocStats(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) in libterarkdb.a(malloc_stats.cc.o)
     (maybe you meant: _je_malloc_usable_size)
  "_mallocx", referenced from:
      terarkdb::DumpMallocStats(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) in libterarkdb.a(malloc_stats.cc.o)
     (maybe you meant: _je_mallocx)
  "_nallocx", referenced from:
      terarkdb::DumpMallocStats(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) in libterarkdb.a(malloc_stats.cc.o)
     (maybe you meant: _je_nallocx)
  "_rallocx", referenced from:
      terarkdb::DumpMallocStats(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) in libterarkdb.a(malloc_stats.cc.o)
     (maybe you meant: _je_rallocx)
  "_sallocx", referenced from:
      terarkdb::DumpMallocStats(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) in libterarkdb.a(malloc_stats.cc.o)
     (maybe you meant: _je_sallocx)
  "_sdallocx", referenced from:
      terarkdb::DumpMallocStats(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) in libterarkdb.a(malloc_stats.cc.o)
     (maybe you meant: _je_sdallocx_default, _je_je_sdallocx_noflags , _je_sdallocx )
  "_xallocx", referenced from:
      terarkdb::DumpMallocStats(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) in libterarkdb.a(malloc_stats.cc.o)
     (maybe you meant: _je_xallocx)
ld: symbol(s) not found for architecture x86_64
collect2: error: ld returned 1 exit status
```

Anyway, this is still a step towards a successful build on macOS. We may fix the linker issue later.
