### PR TITLE
port the unit test of rocksdb 5294

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# WITH_TESTS=1 WITH_ZNS=1 [METRICS_PATH=...] ./build.sh
+# WITH_TESTS=ON WITH_ZNS=OFF [METRICS_PATH=...] ./build.sh
 #
 set -e
 

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -486,6 +486,37 @@ TEST_P(DBAtomicFlushTest,
   Destroy(options);
 }
 
+TEST_P(DBAtomicFlushTest, PickMemtablesRaceWithBackgroundFlush) {
+  bool atomic_flush = GetParam();
+  Options options = CurrentOptions();
+  options.create_if_missing = true;
+  options.atomic_flush_group = NewAtomicFlushGroup();
+  options.max_write_buffer_number = 4;
+  // Set min_write_buffer_number_to_merge to be greater than 1, so that
+  // a column family with one memtable in the imm will not cause IsFlushPending
+  // to return true when flush_requested_ is false.
+  options.min_write_buffer_number_to_merge = 2;
+  CreateAndReopenWithCF({"pikachu"}, options);
+  ASSERT_EQ(2, handles_.size());
+  ASSERT_OK(dbfull()->PauseBackgroundWork());
+  ASSERT_OK(Put(0, "key00", "value00"));
+  ASSERT_OK(Put(1, "key10", "value10"));
+  FlushOptions flush_opts;
+  flush_opts.wait = false;
+  ASSERT_OK(dbfull()->Flush(flush_opts, handles_));
+  ASSERT_OK(Put(0, "key01", "value01"));
+  // Since max_write_buffer_number is 4, the following flush won't cause write
+  // stall.
+  ASSERT_OK(dbfull()->Flush(flush_opts));
+  ASSERT_OK(dbfull()->DropColumnFamily(handles_[1]));
+  ASSERT_OK(dbfull()->DestroyColumnFamilyHandle(handles_[1]));
+  handles_[1] = nullptr;
+  ASSERT_OK(dbfull()->ContinueBackgroundWork());
+  ASSERT_OK(dbfull()->TEST_WaitForFlushMemTable(handles_[0]));
+  delete handles_[0];
+  handles_.clear();
+}
+
 INSTANTIATE_TEST_CASE_P(DBFlushDirectIOTest, DBFlushDirectIOTest,
                         testing::Bool());
 


### PR DESCRIPTION
- Port the unit test of PR 5294 from RocksDB to terarkdb. The unit test can pass in terarkdb without any issues.

Reference to 5294:
https://github.com/facebook/rocksdb/commit/570d490a3de49802cdc406d5de6bfadcb83e1ea4

- Fix the command in  ./build.sh