### PR TITLE
Remove unnecessary InternalComparator param for TableCache

### DIFF
--- a/db/builder.cc
+++ b/db/builder.cc
@@ -457,7 +457,7 @@ Status BuildTable(
       ro.fill_cache = false;
       for (auto& meta : *meta_vec) {
         std::unique_ptr<InternalIterator> it(table_cache->NewIterator(
-            ro, env_options, internal_comparator, meta, empty_dependence_map,
+            ro, env_options, meta, empty_dependence_map,
             nullptr /* range_del_agg */,
             mutable_cf_options.prefix_extractor.get(), nullptr,
             (internal_stats == nullptr) ? nullptr

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -453,8 +453,7 @@ ColumnFamilyData::ColumnFamilyData(
   if (_dummy_versions != nullptr) {
     internal_stats_.reset(
         new InternalStats(ioptions_.num_levels, db_options.env, this));
-    table_cache_.reset(new TableCache(initial_cf_options_, db_options,
-                                      &env_options, _table_cache));
+    table_cache_.reset(new TableCache(ioptions_, env_options, _table_cache));
     if (ioptions_.compaction_style == kCompactionStyleLevel) {
       compaction_picker_.reset(new LevelCompactionPicker(
           table_cache_.get(), env_options, ioptions_, &internal_comparator_));

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -453,8 +453,8 @@ ColumnFamilyData::ColumnFamilyData(
   if (_dummy_versions != nullptr) {
     internal_stats_.reset(
         new InternalStats(ioptions_.num_levels, db_options.env, this));
-    table_cache_.reset(new TableCache(initial_cf_options_,
-                                  db_options, &env_options, _table_cache));
+    table_cache_.reset(new TableCache(initial_cf_options_, db_options,
+                                      &env_options, _table_cache));
     if (ioptions_.compaction_style == kCompactionStyleLevel) {
       compaction_picker_.reset(new LevelCompactionPicker(
           table_cache_.get(), env_options, ioptions_, &internal_comparator_));

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -453,7 +453,8 @@ ColumnFamilyData::ColumnFamilyData(
   if (_dummy_versions != nullptr) {
     internal_stats_.reset(
         new InternalStats(ioptions_.num_levels, db_options.env, this));
-    table_cache_.reset(new TableCache(ioptions_, env_options, _table_cache));
+    table_cache_.reset(new TableCache(initial_cf_options_,
+                                  db_options, &env_options, _table_cache));
     if (ioptions_.compaction_style == kCompactionStyleLevel) {
       compaction_picker_.reset(new LevelCompactionPicker(
           table_cache_.get(), env_options, ioptions_, &internal_comparator_));

--- a/db/compaction_job.cc
+++ b/db/compaction_job.cc
@@ -468,7 +468,7 @@ struct CompactionJob::SubcompactionState {
                            const DependenceMap& depend_map, Arena* arena,
                            TableReader** table_reader_ptr) {
       return table_cache->NewIterator(
-          ReadOptions(), job->env_options_, icmp, *file_metadata, depend_map,
+          ReadOptions(), job->env_options_, *file_metadata, depend_map,
           nullptr, compaction->mutable_cf_options()->prefix_extractor.get(),
           table_reader_ptr, nullptr, false, arena, true, -1);
     };
@@ -531,7 +531,7 @@ struct CompactionJob::SubcompactionState {
             compaction->column_family_data()->table_cache();
         Cache::Handle* handle = nullptr;
         auto s = table_cache->FindTable(
-            job->env_options_, icmp, meta->fd, &handle,
+            job->env_options_, meta->fd, &handle,
             compaction->mutable_cf_options()->prefix_extractor.get());
         if (!s.ok()) {
           return s;
@@ -1349,7 +1349,7 @@ Status CompactionJob::VerifyFiles() {
       ReadOptions ro;
       ro.fill_cache = false;
       InternalIterator* iter = cfd->table_cache()->NewIterator(
-          ro, env_options_, cfd->internal_comparator(), *files_meta[file_idx],
+          ro, env_options_, *files_meta[file_idx],
           empty_dependence_map, nullptr /* range_del_agg */, prefix_extractor,
           nullptr,
           output_level == -1
@@ -2705,7 +2705,7 @@ Status CompactionJob::InstallCompactionResults(
         ReadOptions ro;
         ro.fill_cache = false;
         InternalIterator* iter = cfd->table_cache()->NewIterator(
-            ro, env_options_, cfd->internal_comparator(), o.file_meta,
+            ro, env_options_, o.file_meta,
             empty_dependence_map, nullptr /* range_del_agg */,
             mutable_cf_options.prefix_extractor.get(), nullptr,
             cfd->internal_stats()->GetFileReadHist(compaction->output_level()),
@@ -2788,7 +2788,7 @@ Status CompactionJob::InstallCompactionResults(
       ReadOptions ro;
       ro.fill_cache = false;
       InternalIterator* iter = cfd->table_cache()->NewIterator(
-          ro, env_options_, cfd->internal_comparator(), file_meta,
+          ro, env_options_, file_meta,
           empty_dependence_map, nullptr /* range_del_agg */,
           mutable_cf_options.prefix_extractor.get(), nullptr,
           cfd->internal_stats()->GetFileReadHist(compaction->output_level()),

--- a/db/compaction_job.cc
+++ b/db/compaction_job.cc
@@ -468,8 +468,8 @@ struct CompactionJob::SubcompactionState {
                            const DependenceMap& depend_map, Arena* arena,
                            TableReader** table_reader_ptr) {
       return table_cache->NewIterator(
-          ReadOptions(), job->env_options_, *file_metadata, depend_map,
-          nullptr, compaction->mutable_cf_options()->prefix_extractor.get(),
+          ReadOptions(), job->env_options_, *file_metadata, depend_map, nullptr,
+          compaction->mutable_cf_options()->prefix_extractor.get(),
           table_reader_ptr, nullptr, false, arena, true, -1);
     };
     InternalKey internal_begin, internal_end;
@@ -1349,9 +1349,8 @@ Status CompactionJob::VerifyFiles() {
       ReadOptions ro;
       ro.fill_cache = false;
       InternalIterator* iter = cfd->table_cache()->NewIterator(
-          ro, env_options_, *files_meta[file_idx],
-          empty_dependence_map, nullptr /* range_del_agg */, prefix_extractor,
-          nullptr,
+          ro, env_options_, *files_meta[file_idx], empty_dependence_map,
+          nullptr /* range_del_agg */, prefix_extractor, nullptr,
           output_level == -1
               ? nullptr
               : cfd->internal_stats()->GetFileReadHist(output_level),
@@ -2705,8 +2704,8 @@ Status CompactionJob::InstallCompactionResults(
         ReadOptions ro;
         ro.fill_cache = false;
         InternalIterator* iter = cfd->table_cache()->NewIterator(
-            ro, env_options_, o.file_meta,
-            empty_dependence_map, nullptr /* range_del_agg */,
+            ro, env_options_, o.file_meta, empty_dependence_map,
+            nullptr /* range_del_agg */,
             mutable_cf_options.prefix_extractor.get(), nullptr,
             cfd->internal_stats()->GetFileReadHist(compaction->output_level()),
             false, nullptr /* arena */, false /* skip_filters */,
@@ -2788,8 +2787,8 @@ Status CompactionJob::InstallCompactionResults(
       ReadOptions ro;
       ro.fill_cache = false;
       InternalIterator* iter = cfd->table_cache()->NewIterator(
-          ro, env_options_, file_meta,
-          empty_dependence_map, nullptr /* range_del_agg */,
+          ro, env_options_, file_meta, empty_dependence_map,
+          nullptr /* range_del_agg */,
           mutable_cf_options.prefix_extractor.get(), nullptr,
           cfd->internal_stats()->GetFileReadHist(compaction->output_level()),
           false, nullptr /* arena */, false /* skip_filters */,

--- a/db/compaction_picker.cc
+++ b/db/compaction_picker.cc
@@ -1007,7 +1007,7 @@ void CompactionPicker::InitFilesBeingCompact(
                          const DependenceMap& depend_map, Arena* arena,
                          TableReader** table_reader_ptr) {
     return table_cache_->NewIterator(
-        options, env_options_, *icmp_, *file_metadata, depend_map, nullptr,
+        options, env_options_, *file_metadata, depend_map, nullptr,
         mutable_cf_options.prefix_extractor.get(), table_reader_ptr, nullptr,
         false, arena, true, -1);
   };
@@ -1341,7 +1341,7 @@ Compaction* CompactionPicker::PickRangeCompaction(
                          const DependenceMap& depend_map, Arena* arena,
                          TableReader** table_reader_ptr) {
     return table_cache_->NewIterator(
-        options, env_options_, *icmp_, *file_metadata, depend_map, nullptr,
+        options, env_options_, *file_metadata, depend_map, nullptr,
         mutable_cf_options.prefix_extractor.get(), table_reader_ptr, nullptr,
         false, arena, true, -1);
   };
@@ -1847,7 +1847,7 @@ Compaction* CompactionPicker::PickCompositeCompaction(
                          const DependenceMap& dependence_map, Arena* arena,
                          TableReader** reader) {
     return table_cache_->NewIterator(
-        options, env_options_, *icmp_, *f, dependence_map, nullptr,
+        options, env_options_, *f, dependence_map, nullptr,
         mutable_cf_options.prefix_extractor.get(), nullptr, nullptr, false,
         arena, true, input.level);
   };
@@ -1889,7 +1889,7 @@ Compaction* CompactionPicker::PickCompositeCompaction(
       }
       std::shared_ptr<const TableProperties> tp;
       auto s = table_cache_->GetTableProperties(
-          env_options_, *icmp_, *f, &tp,
+          env_options_, *f, &tp,
           mutable_cf_options.prefix_extractor.get(), true);
       if (s.IsIncomplete()) {
         if (f->fd.largest_seqno < oldest_snapshot_seqnum) {
@@ -2511,7 +2511,7 @@ Compaction* LevelCompactionBuilder::PickLazyCompaction(
                            const DependenceMap& depend_map, Arena* arena,
                            TableReader** table_reader_ptr) {
       return picker->table_cache()->NewIterator(
-          options, picker->env_options(), ioptions_.internal_comparator,
+          options, picker->env_options(),
           *file_metadata, depend_map, nullptr,
           mutable_cf_options_.prefix_extractor.get(), table_reader_ptr, nullptr,
           false, arena, true, -1);
@@ -2732,7 +2732,7 @@ Compaction* LevelCompactionBuilder::PickLazyCompaction(
                            const DependenceMap& depend_map, Arena* arena,
                            TableReader** table_reader_ptr) {
       return picker->table_cache()->NewIterator(
-          options, picker->env_options(), ioptions_.internal_comparator,
+          options, picker->env_options(),
           *file_metadata, depend_map, nullptr,
           mutable_cf_options_.prefix_extractor.get(), table_reader_ptr, nullptr,
           false, arena, true, -1);

--- a/db/compaction_picker.cc
+++ b/db/compaction_picker.cc
@@ -1889,8 +1889,8 @@ Compaction* CompactionPicker::PickCompositeCompaction(
       }
       std::shared_ptr<const TableProperties> tp;
       auto s = table_cache_->GetTableProperties(
-          env_options_, *f, &tp,
-          mutable_cf_options.prefix_extractor.get(), true);
+          env_options_, *f, &tp, mutable_cf_options.prefix_extractor.get(),
+          true);
       if (s.IsIncomplete()) {
         if (f->fd.largest_seqno < oldest_snapshot_seqnum) {
           return false;
@@ -2511,8 +2511,7 @@ Compaction* LevelCompactionBuilder::PickLazyCompaction(
                            const DependenceMap& depend_map, Arena* arena,
                            TableReader** table_reader_ptr) {
       return picker->table_cache()->NewIterator(
-          options, picker->env_options(),
-          *file_metadata, depend_map, nullptr,
+          options, picker->env_options(), *file_metadata, depend_map, nullptr,
           mutable_cf_options_.prefix_extractor.get(), table_reader_ptr, nullptr,
           false, arena, true, -1);
     };
@@ -2732,8 +2731,7 @@ Compaction* LevelCompactionBuilder::PickLazyCompaction(
                            const DependenceMap& depend_map, Arena* arena,
                            TableReader** table_reader_ptr) {
       return picker->table_cache()->NewIterator(
-          options, picker->env_options(),
-          *file_metadata, depend_map, nullptr,
+          options, picker->env_options(), *file_metadata, depend_map, nullptr,
           mutable_cf_options_.prefix_extractor.get(), table_reader_ptr, nullptr,
           false, arena, true, -1);
     };

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -185,7 +185,7 @@ class TablePropertiesCollectionIteratorImpl
       filename_ = TableFileName(cfd_->ioptions()->cf_paths, f->fd.GetNumber(),
                                 f->fd.GetPathId());
       status_ = cfd_->table_cache()->GetTableProperties(
-          impl_->env_options(), cfd_->internal_comparator(), *f, &properties_,
+          impl_->env_options(), *f, &properties_,
           prefix_extractor_.get(), false);
     }
     if (status_.ok()) {

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -185,8 +185,8 @@ class TablePropertiesCollectionIteratorImpl
       filename_ = TableFileName(cfd_->ioptions()->cf_paths, f->fd.GetNumber(),
                                 f->fd.GetPathId());
       status_ = cfd_->table_cache()->GetTableProperties(
-          impl_->env_options(), *f, &properties_,
-          prefix_extractor_.get(), false);
+          impl_->env_options(), *f, &properties_, prefix_extractor_.get(),
+          false);
     }
     if (status_.ok()) {
       iter_ = where;

--- a/db/forward_iterator.cc
+++ b/db/forward_iterator.cc
@@ -71,7 +71,7 @@ class ForwardLevelIterator : public InternalIterator {
     ReadRangeDelAggregator range_del_agg(&cfd_->internal_comparator(),
                                          kMaxSequenceNumber /* upper_bound */);
     file_iter_ = cfd_->table_cache()->NewIterator(
-        read_options_, *(cfd_->soptions()), cfd_->internal_comparator(),
+        read_options_, *(cfd_->soptions()),
         *files_[file_index_], dependence_map_,
         read_options_.ignore_range_deletions ? nullptr : &range_del_agg,
         prefix_extractor_, nullptr /* table_reader_ptr */, nullptr, false);
@@ -560,7 +560,7 @@ void ForwardIterator::RebuildIterators(bool refresh_sv) {
       continue;
     }
     l0_iters_.push_back(cfd_->table_cache()->NewIterator(
-        read_options_, *cfd_->soptions(), cfd_->internal_comparator(), *l0,
+        read_options_, *cfd_->soptions(), *l0,
         vstorage->dependence_map(),
         read_options_.ignore_range_deletions ? nullptr : &range_del_agg,
         sv_->mutable_cf_options.prefix_extractor.get()));
@@ -631,7 +631,7 @@ void ForwardIterator::RenewIterators() {
       continue;
     }
     l0_iters_new.push_back(cfd_->table_cache()->NewIterator(
-        read_options_, *cfd_->soptions(), cfd_->internal_comparator(),
+        read_options_, *cfd_->soptions(),
         *l0_files_new[inew], vstorage_new->dependence_map(),
         read_options_.ignore_range_deletions ? nullptr : &range_del_agg,
         svnew->mutable_cf_options.prefix_extractor.get()));
@@ -690,7 +690,7 @@ void ForwardIterator::ResetIncompleteIterators() {
     }
     DeleteIterator(l0_iters_[i]);
     l0_iters_[i] = cfd_->table_cache()->NewIterator(
-        read_options_, *cfd_->soptions(), cfd_->internal_comparator(),
+        read_options_, *cfd_->soptions(),
         *l0_files[i], vstorage.dependence_map(), nullptr /* range_del_agg */,
         sv_->mutable_cf_options.prefix_extractor.get());
   }

--- a/db/forward_iterator.cc
+++ b/db/forward_iterator.cc
@@ -71,8 +71,8 @@ class ForwardLevelIterator : public InternalIterator {
     ReadRangeDelAggregator range_del_agg(&cfd_->internal_comparator(),
                                          kMaxSequenceNumber /* upper_bound */);
     file_iter_ = cfd_->table_cache()->NewIterator(
-        read_options_, *(cfd_->soptions()),
-        *files_[file_index_], dependence_map_,
+        read_options_, *(cfd_->soptions()), *files_[file_index_],
+        dependence_map_,
         read_options_.ignore_range_deletions ? nullptr : &range_del_agg,
         prefix_extractor_, nullptr /* table_reader_ptr */, nullptr, false);
     valid_ = false;
@@ -560,8 +560,7 @@ void ForwardIterator::RebuildIterators(bool refresh_sv) {
       continue;
     }
     l0_iters_.push_back(cfd_->table_cache()->NewIterator(
-        read_options_, *cfd_->soptions(), *l0,
-        vstorage->dependence_map(),
+        read_options_, *cfd_->soptions(), *l0, vstorage->dependence_map(),
         read_options_.ignore_range_deletions ? nullptr : &range_del_agg,
         sv_->mutable_cf_options.prefix_extractor.get()));
   }
@@ -631,8 +630,8 @@ void ForwardIterator::RenewIterators() {
       continue;
     }
     l0_iters_new.push_back(cfd_->table_cache()->NewIterator(
-        read_options_, *cfd_->soptions(),
-        *l0_files_new[inew], vstorage_new->dependence_map(),
+        read_options_, *cfd_->soptions(), *l0_files_new[inew],
+        vstorage_new->dependence_map(),
         read_options_.ignore_range_deletions ? nullptr : &range_del_agg,
         svnew->mutable_cf_options.prefix_extractor.get()));
   }
@@ -690,8 +689,8 @@ void ForwardIterator::ResetIncompleteIterators() {
     }
     DeleteIterator(l0_iters_[i]);
     l0_iters_[i] = cfd_->table_cache()->NewIterator(
-        read_options_, *cfd_->soptions(),
-        *l0_files[i], vstorage.dependence_map(), nullptr /* range_del_agg */,
+        read_options_, *cfd_->soptions(), *l0_files[i],
+        vstorage.dependence_map(), nullptr /* range_del_agg */,
         sv_->mutable_cf_options.prefix_extractor.get());
   }
 

--- a/db/map_builder.cc
+++ b/db/map_builder.cc
@@ -87,7 +87,7 @@ struct IteratorCacheContext {
     read_options.total_order_seek = true;
 
     return ctx->cfd->table_cache()->NewIterator(
-        read_options, *ctx->env_options, ctx->cfd->internal_comparator(), *f,
+        read_options, *ctx->env_options, *f,
         f->prop.is_map_sst() ? empty_dependence_map : dependence_map,
         nullptr /* range_del_agg */,
         ctx->mutable_cf_options->prefix_extractor.get(), reader_ptr,

--- a/db/map_builder_test.cc
+++ b/db/map_builder_test.cc
@@ -201,10 +201,9 @@ class MapBuilderTest : public testing::Test {
     Status s;
     DependenceMap empty_dependence_map;
     std::unique_ptr<InternalIterator> iter(cfd_->table_cache()->NewIterator(
-        ReadOptions(), env_options_, *f,
-        empty_dependence_map, nullptr /* range_del_agg */,
-        mutable_cf_options_.prefix_extractor.get(), nullptr, nullptr,
-        false /* for_compaction */, nullptr /* arena */,
+        ReadOptions(), env_options_, *f, empty_dependence_map,
+        nullptr /* range_del_agg */, mutable_cf_options_.prefix_extractor.get(),
+        nullptr, nullptr, false /* for_compaction */, nullptr /* arena */,
         false /* skip_filter */, 1));
     s = iter->status();
     if (!s.ok()) {

--- a/db/map_builder_test.cc
+++ b/db/map_builder_test.cc
@@ -201,7 +201,7 @@ class MapBuilderTest : public testing::Test {
     Status s;
     DependenceMap empty_dependence_map;
     std::unique_ptr<InternalIterator> iter(cfd_->table_cache()->NewIterator(
-        ReadOptions(), env_options_, cfd_->internal_comparator(), *f,
+        ReadOptions(), env_options_, *f,
         empty_dependence_map, nullptr /* range_del_agg */,
         mutable_cf_options_.prefix_extractor.get(), nullptr, nullptr,
         false /* for_compaction */, nullptr /* arena */,

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -116,8 +116,8 @@ class Repairer {
             // TableCache can be small since we expect each table to be opened
             // once.
             NewLRUCache(10, db_options_.table_cache_numshardbits)),
-        table_cache_(new TableCache(default_cf_opts_, immutable_db_options_,
-                                    &env_options_, raw_table_cache_.get())),
+        table_cache_(new TableCache(default_cf_iopts_, env_options_,
+                                    raw_table_cache_.get())),
         wb_(db_options_.db_write_buffer_size),
         wc_(db_options_.delayed_write_rate),
         vset_(dbname_, &immutable_db_options_, env_options_,

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -580,8 +580,7 @@ class Repairer {
                                 file_size);
     std::shared_ptr<const TableProperties> props;
     if (status.ok()) {
-      status = table_cache_->GetTableProperties(env_options_, t->meta,
-                                                &props);
+      status = table_cache_->GetTableProperties(env_options_, t->meta, &props);
     }
     if (status.ok()) {
       t->column_family_id = static_cast<uint32_t>(props->column_family_id);
@@ -622,8 +621,8 @@ class Repairer {
       // P.S. depend files in VersionStorage has not build yet ...
       DependenceMap empty_dependence_map;
       InternalIterator* iter = table_cache_->NewIterator(
-          ReadOptions(), env_options_, t->meta,
-          empty_dependence_map, nullptr /* range_del_agg */,
+          ReadOptions(), env_options_, t->meta, empty_dependence_map,
+          nullptr /* range_del_agg */,
           cfd->GetLatestMutableCFOptions()->prefix_extractor.get());
       bool empty = true;
       ParsedInternalKey parsed;

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -116,8 +116,8 @@ class Repairer {
             // TableCache can be small since we expect each table to be opened
             // once.
             NewLRUCache(10, db_options_.table_cache_numshardbits)),
-        table_cache_(new TableCache(default_cf_iopts_, env_options_,
-                                    raw_table_cache_.get())),
+        table_cache_(new TableCache(default_cf_opts_, immutable_db_options_,
+                                    &env_options_, raw_table_cache_.get())),
         wb_(db_options_.db_write_buffer_size),
         wc_(db_options_.delayed_write_rate),
         vset_(dbname_, &immutable_db_options_, env_options_,
@@ -580,7 +580,7 @@ class Repairer {
                                 file_size);
     std::shared_ptr<const TableProperties> props;
     if (status.ok()) {
-      status = table_cache_->GetTableProperties(env_options_, icmp_, t->meta,
+      status = table_cache_->GetTableProperties(env_options_, t->meta,
                                                 &props);
     }
     if (status.ok()) {
@@ -622,7 +622,7 @@ class Repairer {
       // P.S. depend files in VersionStorage has not build yet ...
       DependenceMap empty_dependence_map;
       InternalIterator* iter = table_cache_->NewIterator(
-          ReadOptions(), env_options_, cfd->internal_comparator(), t->meta,
+          ReadOptions(), env_options_, t->meta,
           empty_dependence_map, nullptr /* range_del_agg */,
           cfd->GetLatestMutableCFOptions()->prefix_extractor.get());
       bool empty = true;

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -70,13 +70,12 @@ class TableCache {
   //    returns non-ok status.
   // @param skip_filters Disables loading/accessing the filter block
   // @param level The level this table is at, -1 for "not set / don't know"
-  Status Get(const ReadOptions& options,
-             const FileMetaData& file_meta, const DependenceMap& dependence_map,
-             const Slice& k, GetContext* get_context,
+  Status Get(const ReadOptions& options, const FileMetaData& file_meta,
+             const DependenceMap& dependence_map, const Slice& k,
+             GetContext* get_context,
              const SliceTransform* prefix_extractor = nullptr,
              HistogramImpl* file_read_hist = nullptr, bool skip_filters = false,
-             int level = -1,
-             const FileMetaData* inheritance = nullptr);
+             int level = -1, const FileMetaData* inheritance = nullptr);
 
   // Evict any entry for the specified file number
   static void Evict(Cache* cache, uint64_t file_number);
@@ -88,8 +87,8 @@ class TableCache {
   // Find table reader
   // @param skip_filters Disables loading/accessing the filter block
   // @param level == -1 means not specified
-  Status FindTable(const EnvOptions& toptions,
-                   const FileDescriptor& file_fd, Cache::Handle**,
+  Status FindTable(const EnvOptions& toptions, const FileDescriptor& file_fd,
+                   Cache::Handle**,
                    const SliceTransform* prefix_extractor = nullptr,
                    const bool no_io = false, bool record_read_stats = true,
                    HistogramImpl* file_read_hist = nullptr,
@@ -115,8 +114,7 @@ class TableCache {
   // Return total memory usage of the table reader of the file.
   // 0 if table reader of the file is not loaded.
   size_t GetMemoryUsageByTableReader(
-      const EnvOptions& toptions,
-      const FileDescriptor& fd,
+      const EnvOptions& toptions, const FileDescriptor& fd,
       const SliceTransform* prefix_extractor = nullptr);
 
   // Release the handle from a cache
@@ -138,10 +136,9 @@ class TableCache {
 
  private:
   // Build a table reader
-  Status GetTableReader(const EnvOptions& env_options,
-                        const FileDescriptor& fd, bool sequential_mode,
-                        size_t readahead, bool record_read_stats,
-                        HistogramImpl* file_read_hist,
+  Status GetTableReader(const EnvOptions& env_options, const FileDescriptor& fd,
+                        bool sequential_mode, size_t readahead,
+                        bool record_read_stats, HistogramImpl* file_read_hist,
                         std::unique_ptr<TableReader>* table_reader,
                         const SliceTransform* prefix_extractor = nullptr,
                         bool skip_filters = false, int level = -1,

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -37,9 +37,8 @@ class HistogramImpl;
 
 class TableCache {
  public:
-  TableCache(const ColumnFamilyOptions& initial_cf_options,
-             const ImmutableDBOptions& db_options,
-             const EnvOptions* storage_options, Cache* cache);
+  TableCache(const ImmutableCFOptions& ioptions,
+             const EnvOptions& storage_options, Cache* cache);
   ~TableCache();
 
   // Return an iterator for the specified file number (the corresponding
@@ -154,8 +153,7 @@ class TableCache {
                             bool prefetch_index_and_filter_in_cache,
                             bool for_compaction, bool force_memory);
 
-  const ColumnFamilyOptions initial_cf_options_;
-  const ImmutableCFOptions ioptions_;
+  const ImmutableCFOptions& ioptions_;
   const EnvOptions& env_options_;
   Cache* const cache_;
   bool immortal_tables_;

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -37,8 +37,9 @@ class HistogramImpl;
 
 class TableCache {
  public:
-  TableCache(const ImmutableCFOptions& ioptions,
-             const EnvOptions& storage_options, Cache* cache);
+  TableCache(const ColumnFamilyOptions& initial_cf_options,
+             const ImmutableDBOptions& db_options,
+             const EnvOptions* storage_options, Cache* cache);
   ~TableCache();
 
   // Return an iterator for the specified file number (the corresponding
@@ -54,7 +55,6 @@ class TableCache {
   // @param level The level this table is at, -1 for "not set / don't know"
   InternalIterator* NewIterator(
       const ReadOptions& options, const EnvOptions& toptions,
-      const InternalKeyComparator& internal_comparator,
       const FileMetaData& file_meta, const DependenceMap& dependence_map,
       RangeDelAggregator* range_del_agg,
       const SliceTransform* prefix_extractor = nullptr,
@@ -71,7 +71,6 @@ class TableCache {
   // @param skip_filters Disables loading/accessing the filter block
   // @param level The level this table is at, -1 for "not set / don't know"
   Status Get(const ReadOptions& options,
-             const InternalKeyComparator& internal_comparator,
              const FileMetaData& file_meta, const DependenceMap& dependence_map,
              const Slice& k, GetContext* get_context,
              const SliceTransform* prefix_extractor = nullptr,
@@ -90,7 +89,6 @@ class TableCache {
   // @param skip_filters Disables loading/accessing the filter block
   // @param level == -1 means not specified
   Status FindTable(const EnvOptions& toptions,
-                   const InternalKeyComparator& internal_comparator,
                    const FileDescriptor& file_fd, Cache::Handle**,
                    const SliceTransform* prefix_extractor = nullptr,
                    const bool no_io = false, bool record_read_stats = true,
@@ -109,7 +107,6 @@ class TableCache {
   //            return Status::Incomplete() if table is not present in cache and
   //            we set `no_io` to be true.
   Status GetTableProperties(const EnvOptions& toptions,
-                            const InternalKeyComparator& internal_comparator,
                             const FileMetaData& file_meta,
                             std::shared_ptr<const TableProperties>* properties,
                             const SliceTransform* prefix_extractor = nullptr,
@@ -119,7 +116,6 @@ class TableCache {
   // 0 if table reader of the file is not loaded.
   size_t GetMemoryUsageByTableReader(
       const EnvOptions& toptions,
-      const InternalKeyComparator& internal_comparator,
       const FileDescriptor& fd,
       const SliceTransform* prefix_extractor = nullptr);
 
@@ -143,7 +139,6 @@ class TableCache {
  private:
   // Build a table reader
   Status GetTableReader(const EnvOptions& env_options,
-                        const InternalKeyComparator& internal_comparator,
                         const FileDescriptor& fd, bool sequential_mode,
                         size_t readahead, bool record_read_stats,
                         HistogramImpl* file_read_hist,
@@ -153,7 +148,6 @@ class TableCache {
                         bool prefetch_index_and_filter_in_cache = true,
                         bool for_compaction = false, bool force_memory = false);
   Status GetTableReaderImpl(const EnvOptions& env_options,
-                            const InternalKeyComparator& internal_comparator,
                             const FileDescriptor& fd, bool sequential_mode,
                             size_t readahead, bool record_read_stats,
                             HistogramImpl* file_read_hist,
@@ -163,10 +157,10 @@ class TableCache {
                             bool prefetch_index_and_filter_in_cache,
                             bool for_compaction, bool force_memory);
 
-  const ImmutableCFOptions& ioptions_;
+  const ColumnFamilyOptions initial_cf_options_;
+  const ImmutableCFOptions ioptions_;
   const EnvOptions& env_options_;
   Cache* const cache_;
-  std::string row_cache_id_;
   bool immortal_tables_;
 };
 

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -781,7 +781,7 @@ class VersionBuilder::Rep {
         auto file_read_hist =
             level >= 0 ? internal_stats->GetFileReadHist(level) : nullptr;
         table_cache_->FindTable(
-            env_options_, *base_vstorage_->InternalComparator(), file_meta->fd,
+            env_options_, file_meta->fd,
             &file_meta->table_reader_handle, prefix_extractor, false /*no_io */,
             true /* record_read_stats */, file_read_hist, false, level,
             prefetch_index_and_filter_in_cache, file_meta->prop.is_map_sst());
@@ -832,7 +832,7 @@ class VersionBuilder::Rep {
         std::shared_ptr<const TableProperties> properties;
 
         auto s = table_cache_->GetTableProperties(
-            env_options_, *base_vstorage_->InternalComparator(), *file_meta,
+            env_options_, *file_meta,
             &properties, prefix_extractor, false /*no_io */);
 
         if (s.ok() && properties) {

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -781,10 +781,10 @@ class VersionBuilder::Rep {
         auto file_read_hist =
             level >= 0 ? internal_stats->GetFileReadHist(level) : nullptr;
         table_cache_->FindTable(
-            env_options_, file_meta->fd,
-            &file_meta->table_reader_handle, prefix_extractor, false /*no_io */,
-            true /* record_read_stats */, file_read_hist, false, level,
-            prefetch_index_and_filter_in_cache, file_meta->prop.is_map_sst());
+            env_options_, file_meta->fd, &file_meta->table_reader_handle,
+            prefix_extractor, false /*no_io */, true /* record_read_stats */,
+            file_read_hist, false, level, prefetch_index_and_filter_in_cache,
+            file_meta->prop.is_map_sst());
         if (file_meta->table_reader_handle != nullptr) {
           // Load table_reader
           file_meta->fd.table_reader = table_cache_->GetTableReaderFromHandle(
@@ -831,9 +831,9 @@ class VersionBuilder::Rep {
         auto* file_meta = files_meta[file_idx];
         std::shared_ptr<const TableProperties> properties;
 
-        auto s = table_cache_->GetTableProperties(
-            env_options_, *file_meta,
-            &properties, prefix_extractor, false /*no_io */);
+        auto s = table_cache_->GetTableProperties(env_options_, *file_meta,
+                                                  &properties, prefix_extractor,
+                                                  false /*no_io */);
 
         if (s.ok() && properties) {
           file_meta->prop.num_entries = properties->num_entries;


### PR DESCRIPTION
Save internal Comparator in TableCache instead of passing through function parameter